### PR TITLE
Slim Down Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,9 @@ COPY . /code
 WORKDIR /code
 
 # Install Lektor's plugins here because they are special
-RUN lektor plugins reinstall
-
-# Build the site
-RUN lektor clean --yes -O /usr/share/nginx/html
-RUN lektor build -f webpack -O /usr/share/nginx/html
+RUN lektor plugins reinstall \
+    # Build the site
+    && lektor clean --yes -O /usr/share/nginx/html \
+    && lektor build -f webpack -O /usr/share/nginx/html \
+    # Clean the cache
+    && rm -rf /root/.cache/lektor

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,6 @@ RUN lektor plugins reinstall \
     && lektor clean --yes -O /usr/share/nginx/html \
     && lektor build -f webpack -O /usr/share/nginx/html \
     # Clean the cache
-    && rm -rf /root/.cache/lektor
+    && rm -rf /root/.cache /root/.npm /code
+
+WORKDIR /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,26 +7,26 @@ COPY Dockerfiles/site.conf /etc/nginx/sites-enabled/eligundry.com
 COPY requirements.txt /opt/requirements.txt
 
 # Install the node dependencies and upgrade the installed packages
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl apt-transport-https apt-utils && \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y curl apt-transport-https apt-utils \
     # Setup node repos
-    echo 'deb https://deb.nodesource.com/node_7.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
-    echo 'deb-src https://deb.nodesource.com/node_7.x jessie main' >> /etc/apt/sources.list.d/nodesource.list && \
-    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    && echo 'deb https://deb.nodesource.com/node_7.x jessie main' > /etc/apt/sources.list.d/nodesource.list \
+    && echo 'deb-src https://deb.nodesource.com/node_7.x jessie main' >> /etc/apt/sources.list.d/nodesource.list \
+    && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
     # Install lektor dependencies
-    apt-get update && \
-    apt-get install -y \
+    && apt-get update \
+    && apt-get install -y \
         nodejs \
         libffi6 \
         libffi-dev \
         libssl-dev \
         python \
         python-pip \
-        python-dev && \
-    pip install -U pip cffi && \
-    pip install -r /opt/requirements.txt && \
-    rm -r /var/lib/apt/lists/*
+        python-dev \
+    && pip install -U pip cffi \
+    && pip install -r /opt/requirements.txt \
+    && rm -r /var/lib/apt/lists/*
 
 # Copy the files
 COPY . /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,13 @@ COPY requirements.txt /opt/requirements.txt
 # Install the node dependencies and upgrade the installed packages
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl apt-transport-https apt-utils
-
-# Setup Node repos
-RUN echo 'deb https://deb.nodesource.com/node_7.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get install -y curl apt-transport-https apt-utils && \
+    # Setup node repos
+    echo 'deb https://deb.nodesource.com/node_7.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
     echo 'deb-src https://deb.nodesource.com/node_7.x jessie main' >> /etc/apt/sources.list.d/nodesource.list && \
-    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-
-# Install lektor dependencies
-RUN apt-get update && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    # Install lektor dependencies
+    apt-get update && \
     apt-get install -y \
         nodejs \
         libffi6 \
@@ -27,7 +25,8 @@ RUN apt-get update && \
         python-pip \
         python-dev && \
     pip install -U pip cffi && \
-    pip install -r /opt/requirements.txt
+    pip install -r /opt/requirements.txt && \
+    rm -r /var/lib/apt/lists/*
 
 # Copy the files
 COPY . /code


### PR DESCRIPTION
I took a look at the Dockerfile and realized that a few of the layers could be merged together and that would make the final image size a bit smaller.

The original image size was 303 MB. That's a huge Docker image, but there really isn't a way around that, as I am slipping static assets into the image. This means that the image will continue to grow as I add more assets to the site. I might want to toss these assets on something like S3 at some point, but my site is extremely low traffic and Docker Hub's storage is free so whatever. What this does impact is local development of my Salt server setup (this will be open sourced once I get out of my own way and finish it), as I need to pull this image on each fresh VM build. It's easily the largest image that I have to pull, so any shrinking of the image is welcome.

In any case, after merging the package installation layers together, I ended up with an image size of ~280 MB, a savings of around ~20 MB. Not bad, but I can do better. I then merged the site compilation layers together, which make the image ~270 MB. At this point, I'm sad that the image isn't smaller so I start poking around in the container looking for things I can delete.

Alright, so `apt` lists are something people delete in Docker images? So, let's delete that. Lektor has to install Python packages in order to compile the website? I don't need those after I compile it, so let's nuke it. What else can I delete? What about the source of the website that I am copying into the container? Can I delete that and save some size? Not really, because the `COPY` command is it's own layer and deleting that directory in a subsequent `RUN` layer doesn't negate that layer at all. But doing that does make the end image smaller because Lektor has to install Node modules there and deleting them results in a huge image size reduction.

So, after all of this, the compressed image size is 241 MB, a reduction of 61 MB! Not bad for a half hour fix.

Which leads to the future: How can I make this image even smaller? The most obvious one to me is getting rid of the `COPY` command for the source website. What that means in practice is that I would need to compile the website outside of the Docker container and only copy the generated website into the container. This is easily doable with a simple makefile, but it would also defeat my entire use case of Docker, which is to contain all the dependencies and build processes inside of a container so I don't have to manage that on any of the machines consuming this website. I might circle back to this, because Lektor isn't that invasive and I suspect that it would yield great gains in image size.