### PR TITLE
Swap out GoodreadsBookshelf with a handrolled solution

### DIFF
--- a/gatsby/src/components/Home/index.tsx
+++ b/gatsby/src/components/Home/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import tw, { styled } from 'twin.macro'
 import GitHubCalendar from 'react-github-calendar'
-import { GoodreadsBookshelf } from 'react-goodreads-shelf'
 import { TwitterTimelineEmbed } from 'react-twitter-embed'
 import { useWindowSize } from 'react-use'
 import LazyLoad from 'react-lazyload'
@@ -12,6 +11,7 @@ import Daylio from '../Daylio/index'
 import { DaylioVariants } from '../Daylio/types'
 import DaylioChart from '../Daylio/Chart'
 import Paper from '../Shared/Paper'
+import Reading from '../Reading'
 
 const Section = styled(Paper.section)`
   ${tw`sm:mx-2 md:mx-2`}
@@ -20,8 +20,17 @@ const Section = styled(Paper.section)`
     ${tw`text-teal-500 italic`}
   }
 
-  & .bookshelf > div > div {
-    grid-template-columns: repeat(auto-fit, minmax(80px, 100px)) !important;
+  & .bookshelf {
+    display: grid;
+    align-items: center;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    column-gap: 1vw;
+    margin: 1vw;
+    text-align: center;
+
+    & img {
+      min-width: 75px;
+    }
   }
 
   &.introduction-hero {
@@ -109,10 +118,9 @@ const Home: React.FC = () => {
           are the books that I'm reading right now.
         </p>
         <div className="bookshelf">
-          <GoodreadsBookshelf
+          <Reading
             shelf="currently-reading"
-            userId={config.goodreads.userID}
-            apiKey={config.goodreads.apiKey}
+            accountID={config.goodreads.userID}
           />
         </div>
       </Section>

--- a/gatsby/src/components/Reading/index.tsx
+++ b/gatsby/src/components/Reading/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import useGoodreadsShelf from './useGoodreads'
+
+interface Props {
+  accountID: string
+  shelf: string
+}
+
+const Reading: React.FC<Props> = ({ accountID, shelf }) => {
+  // With Goodreads deprecating their API, I need to screen scrape my now
+  // reading page to get a pretty view. Luckily, this is pretty easy.
+  const { books } = useGoodreadsShelf(accountID, shelf)
+
+  if (!books) {
+    return null
+  }
+
+  return (
+    <>
+      {books.map(book => (
+        <a
+          href={book.url}
+          title={`${book.title} - ${book.author}`}
+          target="_blank"
+          key={book.isbn}
+        >
+          <img alt={`${book.title} - ${book.author}`} src={book.cover} />
+        </a>
+      ))}
+    </>
+  )
+}
+
+export default Reading

--- a/gatsby/src/components/Reading/useGoodreads.ts
+++ b/gatsby/src/components/Reading/useGoodreads.ts
@@ -20,22 +20,19 @@ export default function useGoodreadsShelf(accountID: string, shelf: string) {
 
       return Array.from(
         goodreadsDocument.querySelectorAll('#booksBody .bookalike')
-      ).map(row => {
-        console.log(row)
-        return {
-          isbn: row.querySelector('td.field.isbn .value').textContent,
-          title: row.querySelector('td.field.title a').getAttribute('title'),
-          author: row.querySelector('td.field.author .value').textContent,
-          cover: row
-            .querySelector('td.field.cover img')
-            .getAttribute('src')
-            // Get the full sized thumbnail
-            .replace(/\._\w+\d+_/, ''),
-          url: `https://www.goodreads.com/${row
-            .querySelector('td.field.cover a')
-            .getAttribute('href')}`,
-        }
-      })
+      ).map(row => ({
+        isbn: row.querySelector('td.field.isbn .value').textContent,
+        title: row.querySelector('td.field.title a').getAttribute('title'),
+        author: row.querySelector('td.field.author .value').textContent,
+        cover: row
+          .querySelector('td.field.cover img')
+          .getAttribute('src')
+          // Get the full sized thumbnail
+          .replace(/\._\w+\d+_/, ''),
+        url: `https://www.goodreads.com/${row
+          .querySelector('td.field.cover a')
+          .getAttribute('href')}`,
+      }))
     }
   )
 

--- a/gatsby/src/components/Reading/useGoodreads.ts
+++ b/gatsby/src/components/Reading/useGoodreads.ts
@@ -1,0 +1,43 @@
+import { useQuery } from 'react-query'
+
+export default function useGoodreadsShelf(accountID: string, shelf: string) {
+  const { isFetching, error, data: books } = useQuery(
+    ['goodreads', accountID, shelf],
+    async () => {
+      const resp = await fetch(
+        `https://cors-anywhere.herokuapp.com/https://www.goodreads.com/review/list/${accountID}?ref=nav_mybooks&shelf=${shelf}`
+      )
+
+      if (!resp.ok) {
+        throw resp
+      }
+
+      const parser = new DOMParser()
+      const goodreadsDocument = parser.parseFromString(
+        await resp.text(),
+        'text/html'
+      )
+
+      return Array.from(
+        goodreadsDocument.querySelectorAll('#booksBody .bookalike')
+      ).map(row => {
+        console.log(row)
+        return {
+          isbn: row.querySelector('td.field.isbn .value').textContent,
+          title: row.querySelector('td.field.title a').getAttribute('title'),
+          author: row.querySelector('td.field.author .value').textContent,
+          cover: row
+            .querySelector('td.field.cover img')
+            .getAttribute('src')
+            // Get the full sized thumbnail
+            .replace(/\._\w+\d+_/, ''),
+          url: `https://www.goodreads.com/${row
+            .querySelector('td.field.cover a')
+            .getAttribute('href')}`,
+        }
+      })
+    }
+  )
+
+  return { isFetching, error, books }
+}


### PR DESCRIPTION
Goodreads is deprecating their API soon. Because I like the bookshelf on
my page, I decided to update it so that it doesn't use the API and
screenscrap directly.

- Add a Goodreads React Hook to fetch the data
- Add a component that reads this data from the Hook and renders it