### PR TITLE
Add Claude Code session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) sessions.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install node dependencies. netlify-cli is a devDependency, so this also
+# makes it available via `pnpm exec netlify`.
+pnpm install
+
+# Pull the dev context environment variables from Netlify and write a .env
+# file, mirroring what .github/workflows/pull-request-ci.yml does. Requires
+# NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID to be set as session secrets.
+if [ -n "${NETLIFY_AUTH_TOKEN:-}" ] && [ -n "${NETLIFY_SITE_ID:-}" ]; then
+  pnpm exec netlify env:list --plain > .env
+  echo "Wrote .env from Netlify."
+else
+  echo "NETLIFY_AUTH_TOKEN or NETLIFY_SITE_ID not set; skipping .env generation." >&2
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,6 +6,9 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Run asynchronously so the session doesn't block on setup.
+echo '{"async": true, "asyncTimeout": 300000}'
+
 cd "$CLAUDE_PROJECT_DIR"
 
 # Install node dependencies. netlify-cli is a devDependency, so this also

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Installs pnpm dependencies (which includes netlify-cli as a devDep) and
pulls the Netlify dev context env vars into .env on remote Claude Code
sessions, mirroring the pull-request-ci.yml workflow.