### PR TITLE
Include HTML pages in sitemap with git-based lastmod dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ This is a personal website built with **Astro** as the main framework, using **P
 - Database schema defined in `src/lib/database/schema.ts`
 - Migrations managed via `drizzle-kit`
 
+### Sitemap
+
+- Custom dynamic sitemap generated at `src/pages/sitemap.xml.ts` (not using `@astrojs/sitemap`)
+- Includes `.astro` pages, `.html` pages, blog posts, and talks
+- Last modified dates are derived from git commit history via `src/lib/lastModified.ts`
+
 ### Deployment
 
 - Configured for Netlify deployment with `@astrojs/netlify` adapter

--- a/src/lib/lastModified.ts
+++ b/src/lib/lastModified.ts
@@ -7,7 +7,7 @@ import daylio from './daylio'
 
 const git = simpleGit()
 
-const getLastModFromFile = async (filePath: string): Promise<Date> => {
+export const getLastModFromFile = async (filePath: string): Promise<Date> => {
   return git
     .log({ file: filePath })
     .then((lg) => (lg.latest?.date ? new Date(lg.latest.date) : new Date()))

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,14 +1,16 @@
+import path from 'node:path'
 import type { APIRoute, AstroInstance } from 'astro'
 import { getCollection } from 'astro:content'
 import { SitemapStream, streamToPromise } from 'sitemap'
 import * as dateFns from 'date-fns'
-import { getLastModifiedForPath } from '../lib/lastModified'
+import { getLastModifiedForPath, getLastModFromFile } from '../lib/lastModified'
 
 export const GET: APIRoute = async () => {
   const sitemap = new SitemapStream({
     hostname: 'https://eligundry.com',
   })
   const astroFiles = import.meta.glob<AstroInstance>('./*.astro')
+  const htmlFiles = import.meta.glob('./**/*.html')
   const posts = await getCollection('blog')
   const talks = await getCollection('talks')
 
@@ -20,6 +22,23 @@ export const GET: APIRoute = async () => {
       sitemap.write({
         url,
         lastmod: dateFns.formatISO(await getLastModifiedForPath(url)),
+        changefreq: 'daily',
+        priority: 0.7,
+      })
+    })
+  )
+
+  await Promise.all(
+    Object.keys(htmlFiles).map(async (globPath) => {
+      const url = globPath
+        .replace(/^\./, '')
+        .replace(/\/index\.html$/, '/')
+        .replace(/\.html$/, '/')
+      const filePath = path.join('src', 'pages', globPath.replace(/^\.\//, ''))
+
+      sitemap.write({
+        url,
+        lastmod: dateFns.formatISO(await getLastModFromFile(filePath)),
         changefreq: 'daily',
         priority: 0.7,
       })

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -29,23 +29,6 @@ export const GET: APIRoute = async () => {
   )
 
   await Promise.all(
-    Object.keys(htmlFiles).map(async (globPath) => {
-      const url = globPath
-        .replace(/^\./, '')
-        .replace(/\/index\.html$/, '/')
-        .replace(/\.html$/, '/')
-      const filePath = path.join('src', 'pages', globPath.replace(/^\.\//, ''))
-
-      sitemap.write({
-        url,
-        lastmod: dateFns.formatISO(await getLastModFromFile(filePath)),
-        changefreq: 'daily',
-        priority: 0.7,
-      })
-    })
-  )
-
-  await Promise.all(
     posts.map(async (post) => {
       const url = `/${post.collection}/${post.slug}/`
 
@@ -65,6 +48,23 @@ export const GET: APIRoute = async () => {
       sitemap.write({
         url,
         lastmod: dateFns.formatISO(await getLastModifiedForPath(url)),
+        changefreq: 'daily',
+        priority: 0.7,
+      })
+    })
+  )
+
+  await Promise.all(
+    Object.keys(htmlFiles).map(async (globPath) => {
+      const url = globPath
+        .replace(/^\./, '')
+        .replace(/\/index\.html$/, '/')
+        .replace(/\.html$/, '/')
+      const filePath = path.join('src', 'pages', globPath.replace(/^\.\//, ''))
+
+      sitemap.write({
+        url,
+        lastmod: dateFns.formatISO(await getLastModFromFile(filePath)),
         changefreq: 'daily',
         priority: 0.7,
       })


### PR DESCRIPTION
The sitemap previously only included .astro pages, blog posts, and talks.
This adds all .html files from the pages directory (horses, web0, saturdays/*)
by globbing for ./**/*.html and deriving URLs from the file paths. Last modified
dates come from git commit history via the now-exported getLastModFromFile.

Also adds a sitemap section to CLAUDE.md.

https://claude.ai/code/session_01HkCY3BoRQPHfzCVsUWyBpr