### PR TITLE
Fall back to colored placeholder when Last.fm cover URL is empty

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -319,10 +319,8 @@ const CodingSection = await getEntry('sections', 'do-you-code')
                     <div
                       role="img"
                       aria-label={alt}
-                      class="bg-base-300"
+                      class:list={['w-full', 'aspect-square', 'bg-base-300']}
                       style={{
-                        width: '146px',
-                        height: '146px',
                         backgroundColor: album.coverColor ?? undefined,
                       }}
                     />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -303,17 +303,30 @@ const CodingSection = await getEntry('sections', 'do-you-code')
                   data-tip={alt}
                   class:list={['sm:tooltip', 'sm:tooltip-primary', 'font-sans']}
                 >
-                  <Image
-                    alt={alt}
-                    src={album.cover}
-                    width={146}
-                    height={146}
-                    quality={90}
-                    format="webp"
-                    loading="lazy"
-                    decoding="async"
-                    style={{ backgroundColor: album.coverColor ?? undefined }}
-                  />
+                  {album.cover ? (
+                    <Image
+                      alt={alt}
+                      src={album.cover}
+                      width={146}
+                      height={146}
+                      quality={90}
+                      format="webp"
+                      loading="lazy"
+                      decoding="async"
+                      style={{ backgroundColor: album.coverColor ?? undefined }}
+                    />
+                  ) : (
+                    <div
+                      role="img"
+                      aria-label={alt}
+                      class="bg-base-300"
+                      style={{
+                        width: '146px',
+                        height: '146px',
+                        backgroundColor: album.coverColor ?? undefined,
+                      }}
+                    />
+                  )}
                 </picture>
               )
             })


### PR DESCRIPTION
Astro's Image component throws ExpectedImage when src is "", which
was breaking production builds whenever Last.fm returned an album
without a cover URL.

https://claude.ai/code/session_01E7ZyjfkeqRdJ5WLSzZL3JM