### PR TITLE
Skip Daylio scales column and accept unknown activities

### DIFF
--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -6,7 +6,7 @@ import {
   blob,
   primaryKey,
 } from 'drizzle-orm/sqlite-core'
-import { MoodNames, ActivityNames, PrivateActivityNames } from '../enums'
+import { MoodNames } from '../enums'
 
 export const timestampSQL = sql`(cast(strftime('%s', 'now') as int))`
 
@@ -22,9 +22,7 @@ export const daylioEntries = sqliteTable('daylio_entries', {
 })
 
 export const daylioActivities = sqliteTable('daylio_activities', {
-  activity: text('activity', {
-    enum: [...ActivityNames, ...PrivateActivityNames],
-  }).primaryKey(),
+  activity: text('activity').primaryKey(),
   private: integer('private').default(0),
   createdAt: integer('createdAt', { mode: 'timestamp' }).default(timestampSQL),
   updatedAt: integer('updatedAt', { mode: 'timestamp' }).default(timestampSQL),

--- a/src/lib/daylio.ts
+++ b/src/lib/daylio.ts
@@ -19,7 +19,6 @@ import {
   MoodNames,
   ActivityMapping,
   ActivityNames,
-  PrivateActivityNames,
 } from './enums'
 import {
   db,
@@ -51,8 +50,9 @@ const csvSchema = z
 
         return activities
       },
-      z.array(z.enum(ActivityNames).or(z.enum(PrivateActivityNames)))
+      z.array(z.string())
     ),
+    scales: z.string().optional(),
     note_title: z.string().optional(),
     note: z.preprocess((val): string[] => {
       if (!val || typeof val !== 'string') {
@@ -74,7 +74,14 @@ const csvSchema = z
     return {
       time,
       note: data.note as string[],
-      ...omit(data, ['full_date', 'time', 'weekday', 'date', 'note']),
+      ...omit(data, [
+        'full_date',
+        'time',
+        'weekday',
+        'date',
+        'note',
+        'scales',
+      ]),
     }
   })
 
@@ -87,14 +94,13 @@ const processCSV = async (buffer: Buffer) => {
       'time',
       'mood',
       'activities',
-      'node_title',
+      'scales',
+      'note_title',
       'note',
     ],
   })
   const entries: ReturnType<(typeof csvSchema)['parse']>[] = []
-  const activities = new Set<
-    (typeof ActivityNames | typeof PrivateActivityNames)[number]
-  >()
+  const activities = new Set<string>()
   let idx = 0
 
   for await (const row of parser) {
@@ -174,7 +180,15 @@ const apiSchema = z
   .object({
     time: z.date(),
     mood: z.enum(MoodNames),
-    activities: z.array(z.enum(ActivityNames)),
+    activities: z.preprocess(
+      (val) =>
+        Array.isArray(val)
+          ? val.filter((a): a is (typeof ActivityNames)[number] =>
+              (ActivityNames as readonly string[]).includes(a)
+            )
+          : val,
+      z.array(z.enum(ActivityNames))
+    ),
     notes: z.array(z.string()).or(z.null()),
   })
   .transform((data) => {

--- a/src/lib/daylio.ts
+++ b/src/lib/daylio.ts
@@ -19,6 +19,7 @@ import {
   MoodNames,
   ActivityMapping,
   ActivityNames,
+  PrivateActivityNames,
 } from './enums'
 import {
   db,
@@ -28,6 +29,16 @@ import {
   timestampSQL,
 } from './database'
 import { formatStubbornDateToISO601 } from './utils'
+
+type KnownActivity =
+  | (typeof ActivityNames)[number]
+  | (typeof PrivateActivityNames)[number]
+// `string & {}` preserves autocomplete for known activity names while still
+// accepting new ones that Daylio introduces.
+type Activity = KnownActivity | (string & {})
+const activitySchema = z
+  .union([z.enum(ActivityNames), z.enum(PrivateActivityNames), z.string()])
+  .transform((val) => val as Activity)
 
 const csvSchema = z
   .object({
@@ -50,7 +61,7 @@ const csvSchema = z
 
         return activities
       },
-      z.array(z.string())
+      z.array(activitySchema)
     ),
     scales: z.string().optional(),
     note_title: z.string().optional(),
@@ -100,7 +111,7 @@ const processCSV = async (buffer: Buffer) => {
     ],
   })
   const entries: ReturnType<(typeof csvSchema)['parse']>[] = []
-  const activities = new Set<string>()
+  const activities = new Set<Activity>()
   let idx = 0
 
   for await (const row of parser) {


### PR DESCRIPTION
## Summary
- Add the new `scales` column (between `activities` and `note_title`) to the Daylio CSV parser so submissions work again after Daylio's export format change.
- Loosen the activity type so Daylio can introduce new activity names: they're now stored in the DB as plain text, and unknown activities are filtered out at read time so the `feelings` Astro collection doesn't break on activities missing from `ActivityNames`.

## Test plan
- [ ] POST a Daylio CSV export containing the new `scales` column to `/api/daylio` and confirm entries import successfully.
- [ ] Verify that a CSV with a new activity (not in `ActivityNames`) imports without error and the activity is stored in `daylio_activities`.
- [ ] Confirm `/feelings` still renders and does not include the unknown activity (only known ones are shown).

https://claude.ai/code/session_01TmrvSXA5fAe15tLnk6pSK5