### PR TITLE
Convert Daylio CSV note delimiters to markdown newlines

### DIFF
--- a/src/lib/daylio.ts
+++ b/src/lib/daylio.ts
@@ -61,7 +61,17 @@ const csvSchema = z
         return null
       }
 
-      return val
+      // Daylio CSV doesn't include newlines. List items are delimited
+      // by '- ' and paragraphs are delimited by double spaces.
+      if (val.startsWith('- ')) {
+        const lines = val
+          .split('- ')
+          .filter((line) => !!line)
+          .map((line) => line.trim())
+        return lines.map((line) => `- ${line}`).join('\n')
+      }
+
+      return val.replace(/  +/g, '\n\n')
     }, z.string().nullable()),
   })
   .transform((data) => {


### PR DESCRIPTION
## Summary

- Daylio's CSV export doesn't include newlines in note fields — list items are delimited by `- ` and paragraphs by double spaces
- Convert these to proper markdown during CSV import: split on `- ` for lists, replace `  +` with `\n\n` for paragraphs
- This was missed from #347 — the fix was pushed after the PR was merged, so the deployed code was still storing raw CSV text without newlines

## Test plan

- [ ] Re-upload Daylio CSV after deploy
- [ ] Verify list entries render as `<ul>` on `/feelings`
- [ ] Verify paragraph entries render as separate `<p>` tags (check `#2026-05-23T15:07:00-04:00`)

https://claude.ai/code/session_01U8S5rvReHnWuBf8EnWFzwn

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8S5rvReHnWuBf8EnWFzwn)_