### PR TITLE
Add e2e tests and improve semantic HTML structure

### DIFF
--- a/.github/workflows/playwright-preview.yml
+++ b/.github/workflows/playwright-preview.yml
@@ -1,0 +1,39 @@
+name: Playwright (Netlify Preview)
+on:
+  deployment_status:
+
+jobs:
+  e2e:
+    name: Run e2e tests against preview
+    if: |
+      github.event.deployment_status.state == 'success' &&
+      startsWith(github.event.deployment.environment, 'Deploy Preview')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ dist
 
 # Netlify cache
 .netlify
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "astro-check": "astro check",
     "type-check": "tsc --noEmit",
     "test": "vitest",
+    "test:e2e": "playwright test",
     "drizzle:migration:generate": "drizzle-kit generate:sqlite --out ./migrations --schema ./src/lib/database/schema.ts",
     "prepare": "husky"
   },
@@ -103,6 +104,7 @@
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.20.0",
     "@originjs/vite-plugin-commonjs": "^1.0.3",
+    "@playwright/test": "^1.60.0",
     "@shikijs/rehype": "^1.29.2",
     "@types/async-retry": "^1.4.9",
     "@types/basic-auth": "^1.1.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4321'
+const isLocal = baseURL.startsWith('http://localhost')
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: isLocal
+    ? {
+        command: 'pnpm dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      }
+    : undefined,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@originjs/vite-plugin-commonjs':
         specifier: ^1.0.3
         version: 1.0.3
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@shikijs/rehype':
         specifier: ^1.29.2
         version: 1.29.2
@@ -3392,6 +3395,14 @@ packages:
         integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==,
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
+
+  '@playwright/test@1.60.0':
+    resolution:
+      {
+        integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution:
@@ -7831,6 +7842,14 @@ packages:
         integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
       }
 
+  fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution:
       {
@@ -11383,6 +11402,22 @@ packages:
       {
         integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==,
       }
+
+  playwright-core@1.60.0:
+    resolution:
+      {
+        integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution:
+      {
+        integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
 
   pngjs@7.0.0:
     resolution:
@@ -16782,6 +16817,10 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -19659,6 +19698,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -22153,6 +22195,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.3
       pathe: 1.1.2
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@7.0.0: {}
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -35,6 +35,23 @@ const links = [
 ]
 ---
 
+<a
+  href="#main-content"
+  class:list={[
+    'sr-only',
+    'focus:not-sr-only',
+    'focus:fixed',
+    'focus:top-2',
+    'focus:left-2',
+    'focus:z-50',
+    'focus:btn',
+    'focus:btn-primary',
+    'focus:btn-sm',
+    'print:hidden',
+  ]}
+>
+  Skip to main content
+</a>
 <progress
   id="scroll-progress"
   aria-label="your scroll progress through the page"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -163,6 +163,7 @@ if (opengraphImage === config.url) {
     <Header />
     <FancyBackground points={fancyBackgroundPoints}>
       <main
+        id="main-content"
         class:list={[
           'container',
           'grow-0',

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -110,9 +110,9 @@ const url = `/${collection}/${slug}/`
         </EmojiText>
       </p>
     </header>
-    <main itemprop="text" class="post-body">
+    <div itemprop="text" class="post-body">
       <slot />
-    </main>
+    </div>
     {
       showComments && (
         <footer>

--- a/src/pages/blog/links/[slug].astro
+++ b/src/pages/blog/links/[slug].astro
@@ -73,8 +73,8 @@ const date = getLinkPostDate(entry.data)
       }
     </header>
     {props.URL && <LinkEmbed url={props.URL} />}
-    <main itemprop="text">
+    <div itemprop="text">
       <Content />
-    </main>
+    </div>
   </article>
 </BaseLayout>

--- a/src/pages/web0.html
+++ b/src/pages/web0.html
@@ -23,49 +23,52 @@
     </style>
   </head>
   <body>
-    <h1>✳️ <a href="http://html.energy">web0 is my future</a> ✳️</h1>
-    <p>
-      there is a lot of buzz around web2 vs web3. a lot of discussion around
-      ownership and data. these are healthy discussions for web professionals to
-      have. for me, tho, web3 seems to be a bunch of librarian grifters trying
-      to shoehorn ayn randian solutions as the one true way for
-      decentralization. when i think of decentralization, i think of bittorrent
-      and information freedom, not artificial scarcity and laser eyes.
-    </p>
-    <p>
-      what i can agree with in web3 is ownership of data and the best way to
-      express that is by having a personal site. you own all the pixels that you
-      can show. you can write pretty much whatever you want and not worry about
-      censorship. this has been around for nearly 30 years! all you need to do
-      is write a little html and push it to a server and boom, you're
-      communicating. this what the <a href="http://html.energy">web0</a> is all
-      about.
-    </p>
-    <p>
-      while i enjoy making <abbr title="Single Page Applications">SPAs</abbr>,
-      sometimes it's soothing to code like my forefathers & foremothers once
-      did. write that html without any javascript. let that text use the default
-      fonts. really focus on your ideas instead of flash. i had a ball making
-      this page. won't you join me and the web0 movement?
-    </p>
-    <p>✳️ <a href="https://eligundry.com">Eli Gundry</a> ✳️</p>
+    <main>
+      <h1>✳️ <a href="http://html.energy">web0 is my future</a> ✳️</h1>
+      <p>
+        there is a lot of buzz around web2 vs web3. a lot of discussion around
+        ownership and data. these are healthy discussions for web professionals
+        to have. for me, tho, web3 seems to be a bunch of librarian grifters
+        trying to shoehorn ayn randian solutions as the one true way for
+        decentralization. when i think of decentralization, i think of
+        bittorrent and information freedom, not artificial scarcity and laser
+        eyes.
+      </p>
+      <p>
+        what i can agree with in web3 is ownership of data and the best way to
+        express that is by having a personal site. you own all the pixels that
+        you can show. you can write pretty much whatever you want and not worry
+        about censorship. this has been around for nearly 30 years! all you need
+        to do is write a little html and push it to a server and boom, you're
+        communicating. this what the <a href="http://html.energy">web0</a> is
+        all about.
+      </p>
+      <p>
+        while i enjoy making <abbr title="Single Page Applications">SPAs</abbr>,
+        sometimes it's soothing to code like my forefathers & foremothers once
+        did. write that html without any javascript. let that text use the
+        default fonts. really focus on your ideas instead of flash. i had a ball
+        making this page. won't you join me and the web0 movement?
+      </p>
+      <p>✳️ <a href="https://eligundry.com">Eli Gundry</a> ✳️</p>
 
-    <section></section>
-    <h2>HTML Energy Projects</h2>
-    <ul>
-      <li>
-        <a href="/saturdays">Saturdays</a>: A poem about the weekly phone calls
-        I have with my brother in law for HTML Day 2025. I dislike AI art in
-        general, but I wanted this to have some polish, so I cheated. My wife
-        and I traveled to Poughkeepsie for this event and she wrote her first
-        HTML ever! It is a treasured memory of mine now.
-      </li>
-      <li>
-        <a href="/horses.html">Horses</a>: A poem I made for HTML Day 2024 about
-        my first (web) job working at a horse farm. I remeber them telling me,
-        when they hired me, that the last person they had ended up in NYC and
-        look at me now.
-      </li>
-    </ul>
+      <section></section>
+      <h2>HTML Energy Projects</h2>
+      <ul>
+        <li>
+          <a href="/saturdays">Saturdays</a>: A poem about the weekly phone
+          calls I have with my brother in law for HTML Day 2025. I dislike AI
+          art in general, but I wanted this to have some polish, so I cheated.
+          My wife and I traveled to Poughkeepsie for this event and she wrote
+          her first HTML ever! It is a treasured memory of mine now.
+        </li>
+        <li>
+          <a href="/horses.html">Horses</a>: A poem I made for HTML Day 2024
+          about my first (web) job working at a horse farm. I remeber them
+          telling me, when they hired me, that the last person they had ended up
+          in NYC and look at me now.
+        </li>
+      </ul>
+    </main>
   </body>
 </html>

--- a/tests/e2e/sitemap.spec.ts
+++ b/tests/e2e/sitemap.spec.ts
@@ -1,59 +1,49 @@
 import { test, expect, request } from '@playwright/test'
+import { JSDOM } from 'jsdom'
 
 const SITEMAP_HOSTNAME = 'https://eligundry.com'
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4321'
 
-async function getSitemapUrls(baseURL: string): Promise<string[]> {
+async function getSitemapUrls(): Promise<string[]> {
   const ctx = await request.newContext()
   const res = await ctx.get(`${baseURL}/sitemap.xml`)
-  expect(res.ok(), `sitemap.xml returned ${res.status()}`).toBeTruthy()
+  if (!res.ok()) {
+    throw new Error(`sitemap.xml returned ${res.status()}`)
+  }
   const xml = await res.text()
   await ctx.dispose()
 
-  const urls = Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) =>
-    m[1].replace(SITEMAP_HOSTNAME, '')
-  )
-  expect(urls.length, 'sitemap should not be empty').toBeGreaterThan(0)
+  const dom = new JSDOM(xml, { contentType: 'text/xml' })
+  const urls = Array.from(dom.window.document.querySelectorAll('url > loc'))
+    .map((el) => el.textContent?.trim() ?? '')
+    .filter(Boolean)
+    .map((url) => url.replace(SITEMAP_HOSTNAME, ''))
+
+  if (urls.length === 0) {
+    throw new Error('sitemap is empty')
+  }
   return urls
 }
 
-test('sitemap pages load without redirects and have main content', async ({
-  page,
-  baseURL,
-}) => {
-  test.slow()
-  const urls = await getSitemapUrls(baseURL!)
-  const failures: string[] = []
+const urls = await getSitemapUrls()
 
+test.describe('sitemap', () => {
   for (const url of urls) {
-    const response = await page.goto(url, { waitUntil: 'domcontentloaded' })
-    if (!response) {
-      failures.push(`${url}: no response`)
-      continue
-    }
+    test(`${url} loads without redirects and has main content`, async ({
+      page,
+    }) => {
+      const response = await page.goto(url, { waitUntil: 'domcontentloaded' })
+      expect(response, 'no response').not.toBeNull()
+      expect(response!.status(), 'expected 200').toBe(200)
+      expect(
+        response!.request().redirectedFrom(),
+        'expected no redirect'
+      ).toBeNull()
 
-    const status = response.status()
-    if (status !== 200) {
-      failures.push(`${url}: status ${status}`)
-      continue
-    }
-
-    if (response.request().redirectedFrom()) {
-      failures.push(`${url}: was redirected`)
-      continue
-    }
-
-    const main = page.locator('main')
-    const count = await main.count()
-    if (count !== 1) {
-      failures.push(`${url}: expected 1 <main>, found ${count}`)
-      continue
-    }
-
-    const text = (await main.innerText()).trim()
-    if (text.length === 0) {
-      failures.push(`${url}: <main> is empty`)
-    }
+      const main = page.locator('main')
+      await expect(main, 'expected exactly one <main>').toHaveCount(1)
+      const text = (await main.innerText()).trim()
+      expect(text.length, '<main> is empty').toBeGreaterThan(0)
+    })
   }
-
-  expect(failures, failures.join('\n')).toEqual([])
 })

--- a/tests/e2e/sitemap.spec.ts
+++ b/tests/e2e/sitemap.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, request } from '@playwright/test'
+
+const SITEMAP_HOSTNAME = 'https://eligundry.com'
+
+async function getSitemapUrls(baseURL: string): Promise<string[]> {
+  const ctx = await request.newContext()
+  const res = await ctx.get(`${baseURL}/sitemap.xml`)
+  expect(res.ok(), `sitemap.xml returned ${res.status()}`).toBeTruthy()
+  const xml = await res.text()
+  await ctx.dispose()
+
+  const urls = Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) =>
+    m[1].replace(SITEMAP_HOSTNAME, '')
+  )
+  expect(urls.length, 'sitemap should not be empty').toBeGreaterThan(0)
+  return urls
+}
+
+test('sitemap pages load without redirects and have main content', async ({
+  page,
+  baseURL,
+}) => {
+  test.slow()
+  const urls = await getSitemapUrls(baseURL!)
+  const failures: string[] = []
+
+  for (const url of urls) {
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded' })
+    if (!response) {
+      failures.push(`${url}: no response`)
+      continue
+    }
+
+    const status = response.status()
+    if (status !== 200) {
+      failures.push(`${url}: status ${status}`)
+      continue
+    }
+
+    if (response.request().redirectedFrom()) {
+      failures.push(`${url}: was redirected`)
+      continue
+    }
+
+    const main = page.locator('main')
+    const count = await main.count()
+    if (count !== 1) {
+      failures.push(`${url}: expected 1 <main>, found ${count}`)
+      continue
+    }
+
+    const text = (await main.innerText()).trim()
+    if (text.length === 0) {
+      failures.push(`${url}: <main> is empty`)
+    }
+  }
+
+  expect(failures, failures.join('\n')).toEqual([])
+})


### PR DESCRIPTION
## Summary

This PR adds end-to-end testing infrastructure using Playwright and improves the semantic HTML structure of the site by wrapping content in `<main>` elements and adding skip-to-content navigation.

## Key Changes

- **E2E Testing Infrastructure**
  - Added Playwright configuration (`playwright.config.ts`) with support for local and preview environments
  - Created sitemap-based e2e test suite (`tests/e2e/sitemap.spec.ts`) that validates all pages load without redirects and contain main content
  - Added GitHub Actions workflow (`playwright-preview.yml`) to run e2e tests against Netlify preview deployments
  - Added `test:e2e` npm script to package.json

- **Semantic HTML Improvements**
  - Wrapped main page content in `<main id="main-content">` element in `Layout.astro`
  - Added skip-to-content link in `Header.astro` for keyboard navigation accessibility
  - Converted `<main>` to `<div>` in `Post.astro` and `[slug].astro` (links) to avoid nested main elements, maintaining semantic structure with `itemprop="text"`
  - Wrapped web0 page content in `<main>` element with proper indentation

- **Configuration Updates**
  - Updated `.gitignore` to exclude Playwright test artifacts and cache directories

## Implementation Details

The e2e test suite dynamically generates tests for all URLs found in the sitemap, ensuring every page:
- Returns a 200 status code
- Has no redirects
- Contains exactly one `<main>` element with non-empty content

The skip-to-content link uses Tailwind utility classes to remain hidden until focused, improving keyboard navigation without affecting visual design.

https://claude.ai/code/session_016t1M4z7C8YVqk1frB1reXi