### PR TITLE
Add tooltips to GitHub contribution calendar blocks

### DIFF
--- a/src/components/GithubCalendar.astro
+++ b/src/components/GithubCalendar.astro
@@ -84,7 +84,11 @@ const height = (blockSize + blockMargin) * 7 - blockMargin
             <rect
               y={(blockSize + blockMargin) * dayIdx}
               class={`level-${day.level}`}
-            />
+            >
+              <title>
+                {`${day.count} contribution${day.count === 1 ? '' : 's'} on ${dateFns.format(day.date, 'MMMM d, yyyy')}`}
+              </title>
+            </rect>
           ))}
         </g>
       )


### PR DESCRIPTION
## Summary
Added SVG `<title>` elements to the GitHub contribution calendar blocks to display contribution details on hover.

## Changes
- Wrapped the `<rect>` element in the GithubCalendar component with a `<title>` child element
- The tooltip displays the contribution count and date in a human-readable format (e.g., "5 contributions on January 15, 2024")
- Properly handles singular/plural grammar for the contribution count

## Implementation Details
- Uses the existing `dateFns.format()` utility to format dates as "MMMM d, yyyy"
- The tooltip text is dynamically generated based on `day.count` and `day.date` properties
- This leverages native SVG tooltip functionality, providing accessible hover information without additional JavaScript

https://claude.ai/code/session_01Qc2WxdkXSacX8omZKu6PA8