### PR TITLE
Add standard.site (ATProto) publishing for blog, links, and feelings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Format code**: `pnpm prettier`
 - **Astro type checking**: `pnpm astro-check`
 - **Generate database migration**: `pnpm drizzle:migration:generate`
+- **Create standard.site publication** (one-time setup): `pnpm standard-site:create-publication`
+- **Publish a static HTML page to standard.site**: `pnpm standard-site:publish-page <file.html>`
 
 ## Architecture Overview
 
@@ -54,6 +56,15 @@ This is a personal website built with **Astro** as the main framework, using **P
 - Custom dynamic sitemap generated at `src/pages/sitemap.xml.ts` (not using `@astrojs/sitemap`)
 - Includes `.astro` pages, `.html` pages, blog posts, and talks
 - Last modified dates are derived from git commit history via `src/lib/lastModified.ts`
+
+### standard.site (ATProto) Publishing
+
+- Publishes content to ATProto via [`@bryanguffey/astro-standard-site`](https://github.com/musicjunkieg/astro-standard-site) using the [standard.site](https://standard.site/) spec
+- Core logic in `src/lib/standardSite.ts`; publishing is triggered inside the prerendered page renders (`src/pages/blog/[...slug].astro`, `src/pages/blog/links/[slug].astro`, `src/pages/feelings.astro`), guarded by `import.meta.env.PROD` and best-effort/non-fatal
+- Blog + Notion link posts publish as `site.standard.document` records and (for recent posts) get a Bluesky announcement so replies render as comments via `src/components/Post/Comments.astro` alongside utteranc.es; feelings mirror the `/feelings.rss` feed
+- Published docs are tracked in the `standard_site_documents` table (Drizzle) and deduped via a content hash
+- Verification endpoint at `src/pages/.well-known/site.standard.publication.ts`; per-document `<link>` tags emitted in post heads
+- Credentials read via static `import.meta.env.*` literals (Astro) with `process.env.*` fallback (vite-node scripts): `BLUESKY_USERNAME`, `BLUESKY_PASSWORD`, `STANDARD_SITE_DID`, `STANDARD_SITE_PUBLICATION_RKEY`
 
 ### Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,7 @@ This is a personal website built with **Astro** as the main framework, using **P
 
 ### standard.site (ATProto) Publishing
 
-- Publishes content to ATProto via [`@bryanguffey/astro-standard-site`](https://github.com/musicjunkieg/astro-standard-site) using the [standard.site](https://standard.site/) spec
-- Core logic in `src/lib/standardSite.ts`; publishing is triggered inside the prerendered page renders (`src/pages/blog/[...slug].astro`, `src/pages/blog/links/[slug].astro`, `src/pages/feelings.astro`), guarded by `import.meta.env.PROD` and best-effort/non-fatal
-- Blog + Notion link posts publish as `site.standard.document` records and (for recent posts) get a Bluesky announcement so replies render as comments via `src/components/Post/Comments.astro` alongside utteranc.es; feelings mirror the `/feelings.rss` feed
-- Published docs are tracked in the `standard_site_documents` table (Drizzle) and deduped via a content hash
-- Verification endpoint at `src/pages/.well-known/site.standard.publication.ts`; per-document `<link>` tags emitted in post heads
-- Credentials read via static `import.meta.env.*` literals (Astro) with `process.env.*` fallback (vite-node scripts): `BLUESKY_USERNAME`, `BLUESKY_PASSWORD`, `STANDARD_SITE_DID`, `STANDARD_SITE_PUBLICATION_RKEY`
+- Publishes blog/link/feelings content (and hand-made static pages) to ATProto via `src/lib/standardSite.ts`, triggered in prerendered page renders and deduped through the `standard_site_documents` table — see [`docs/standard-site.md`](./docs/standard-site.md)
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,51 @@ My personal website.
 ## Deployment
 
 All pushes to main will trigger build on Netlify.
+
+## standard.site (ATProto) Publishing
+
+The site publishes its content to [ATProto](https://atproto.com/) using the
+[standard.site](https://standard.site/) spec via
+[`@bryanguffey/astro-standard-site`](https://github.com/musicjunkieg/astro-standard-site),
+so posts are portable across standard.site readers (Leaflet, Pckt, etc.) and
+can be discussed from Bluesky.
+
+What gets published, automatically on each production build (best-effort and
+non-fatal — skipped when credentials are absent):
+
+- **Blog posts** and **Notion link posts** → `site.standard.document` records.
+  Recent posts also get a Bluesky announcement post so replies show up as
+  comments (alongside the existing [utteranc.es](https://utteranc.es/) thread).
+- **Feelings** (Daylio entries) → documents, mirroring the `/feelings.rss` feed.
+
+Each post carries a `site.standard.document` verification `<link>`, and
+ownership is proven at `/.well-known/site.standard.publication`.
+
+Publishing is deduped via a content hash stored in the `standard_site_documents`
+table, so unchanged content is never re-published.
+
+### Setup / configuration
+
+Credentials are read from the environment (`import.meta.env` in Astro builds,
+`process.env` for scripts):
+
+- `BLUESKY_USERNAME` / `BLUESKY_PASSWORD` — Bluesky handle + app password
+  (reused from the existing Bluesky integration).
+- `STANDARD_SITE_DID` / `STANDARD_SITE_PUBLICATION_RKEY` — produced by the
+  one-time setup script below.
+
+One-time: publish the publication record and write the `STANDARD_SITE_*` vars
+to Netlify (requires the `netlify` CLI to be linked):
+
+```sh
+pnpm standard-site:create-publication
+```
+
+### Publishing hand-made static pages
+
+Blog/links/feelings publish automatically, but the artisanal static HTML pages
+(`horses.html`, `web0.html`, `saturdays/*`, …) are published manually:
+
+```sh
+pnpm standard-site:publish-page src/pages/horses.html [more.html ...]
+```

--- a/README.md
+++ b/README.md
@@ -18,50 +18,6 @@ My personal website.
 
 All pushes to main will trigger build on Netlify.
 
-## standard.site (ATProto) Publishing
+## Documentation
 
-The site publishes its content to [ATProto](https://atproto.com/) using the
-[standard.site](https://standard.site/) spec via
-[`@bryanguffey/astro-standard-site`](https://github.com/musicjunkieg/astro-standard-site),
-so posts are portable across standard.site readers (Leaflet, Pckt, etc.) and
-can be discussed from Bluesky.
-
-What gets published, automatically on each production build (best-effort and
-non-fatal — skipped when credentials are absent):
-
-- **Blog posts** and **Notion link posts** → `site.standard.document` records.
-  Recent posts also get a Bluesky announcement post so replies show up as
-  comments (alongside the existing [utteranc.es](https://utteranc.es/) thread).
-- **Feelings** (Daylio entries) → documents, mirroring the `/feelings.rss` feed.
-
-Each post carries a `site.standard.document` verification `<link>`, and
-ownership is proven at `/.well-known/site.standard.publication`.
-
-Publishing is deduped via a content hash stored in the `standard_site_documents`
-table, so unchanged content is never re-published.
-
-### Setup / configuration
-
-Credentials are read from the environment (`import.meta.env` in Astro builds,
-`process.env` for scripts):
-
-- `BLUESKY_USERNAME` / `BLUESKY_PASSWORD` — Bluesky handle + app password
-  (reused from the existing Bluesky integration).
-- `STANDARD_SITE_DID` / `STANDARD_SITE_PUBLICATION_RKEY` — produced by the
-  one-time setup script below.
-
-One-time: publish the publication record and write the `STANDARD_SITE_*` vars
-to Netlify (requires the `netlify` CLI to be linked):
-
-```sh
-pnpm standard-site:create-publication
-```
-
-### Publishing hand-made static pages
-
-Blog/links/feelings publish automatically, but the artisanal static HTML pages
-(`horses.html`, `web0.html`, `saturdays/*`, …) are published manually:
-
-```sh
-pnpm standard-site:publish-page src/pages/horses.html [more.html ...]
-```
+- [standard.site (ATProto) publishing](./docs/standard-site.md)

--- a/docs/standard-site.md
+++ b/docs/standard-site.md
@@ -1,0 +1,59 @@
+# standard.site (ATProto) Publishing
+
+The site publishes its content to [ATProto](https://atproto.com/) using the
+[standard.site](https://standard.site/) spec via
+[`@bryanguffey/astro-standard-site`](https://github.com/musicjunkieg/astro-standard-site),
+so posts are portable across standard.site readers (Leaflet, Pckt, etc.) and
+can be discussed from Bluesky.
+
+## What gets published
+
+Automatically on each production build (best-effort and non-fatal — skipped
+when credentials are absent):
+
+- **Blog posts** and **Notion link posts** → `site.standard.document` records.
+  Recent posts also get a Bluesky announcement post so replies show up as
+  comments (alongside the existing [utteranc.es](https://utteranc.es/) thread).
+- **Feelings** (Daylio entries) → documents, mirroring the `/feelings.rss` feed.
+
+Each post carries a `site.standard.document` verification `<link>`, and
+ownership is proven at `/.well-known/site.standard.publication`.
+
+Publishing is deduped via a content hash stored in the `standard_site_documents`
+table, so unchanged content is never re-published.
+
+## How it works
+
+- Core logic lives in `src/lib/standardSite.ts` (credential-agnostic publisher
+  wrapper, content-hash dedupe, an announcement-age cutoff, and a per-build cap
+  on feelings to avoid a large backfill burst).
+- Publishing is triggered inside the prerendered page renders
+  (`src/pages/blog/[...slug].astro`, `src/pages/blog/links/[slug].astro`,
+  `src/pages/feelings.astro`), guarded by `import.meta.env.PROD`.
+- Bluesky-powered comments render via `src/components/Post/Comments.astro`.
+
+## Setup / configuration
+
+Credentials are read from the environment (`import.meta.env` in Astro builds,
+`process.env` for scripts):
+
+- `BLUESKY_USERNAME` / `BLUESKY_PASSWORD` — Bluesky handle + app password
+  (reused from the existing Bluesky integration).
+- `STANDARD_SITE_DID` / `STANDARD_SITE_PUBLICATION_RKEY` — produced by the
+  one-time setup script below.
+
+One-time: publish the publication record and write the `STANDARD_SITE_*` vars
+to Netlify (requires the `netlify` CLI to be linked):
+
+```sh
+pnpm standard-site:create-publication
+```
+
+## Publishing hand-made static pages
+
+Blog/links/feelings publish automatically, but the artisanal static HTML pages
+(`horses.html`, `web0.html`, `saturdays/*`, …) are published manually:
+
+```sh
+pnpm standard-site:publish-page src/pages/horses.html [more.html ...]
+```

--- a/migrations/0002_black_human_fly.sql
+++ b/migrations/0002_black_human_fly.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `standard_site_documents` (
+	`path` text PRIMARY KEY NOT NULL,
+	`kind` text NOT NULL,
+	`documentUri` text NOT NULL,
+	`documentRkey` text NOT NULL,
+	`documentCid` text NOT NULL,
+	`bskyPostUri` text,
+	`bskyPostCid` text,
+	`contentHash` text NOT NULL,
+	`publishedAt` integer DEFAULT (cast(strftime('%s', 'now') as int)),
+	`updatedAt` integer DEFAULT (cast(strftime('%s', 'now') as int))
+);

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,259 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "06e1bb2f-fe06-44f6-99d9-d547d3d16dd6",
+  "prevId": "cf4a889c-ba24-4cfe-9df4-6cd86e0db6f7",
+  "tables": {
+    "daylio_activities": {
+      "name": "daylio_activities",
+      "columns": {
+        "activity": {
+          "name": "activity",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private": {
+          "name": "private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daylio_entries": {
+      "name": "daylio_entries",
+      "columns": {
+        "time": {
+          "name": "time",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daylio_entry_activities": {
+      "name": "daylio_entry_activities",
+      "columns": {
+        "time": {
+          "name": "time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity": {
+          "name": "activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daylio_entry_activities_time_daylio_entries_time_fk": {
+          "name": "daylio_entry_activities_time_daylio_entries_time_fk",
+          "tableFrom": "daylio_entry_activities",
+          "tableTo": "daylio_entries",
+          "columnsFrom": ["time"],
+          "columnsTo": ["time"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "daylio_entry_activities_activity_daylio_activities_activity_fk": {
+          "name": "daylio_entry_activities_activity_daylio_activities_activity_fk",
+          "tableFrom": "daylio_entry_activities",
+          "tableTo": "daylio_activities",
+          "columnsFrom": ["activity"],
+          "columnsTo": ["activity"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daylio_entry_activities_time_activity_pk": {
+          "columns": ["time", "activity"],
+          "name": "daylio_entry_activities_time_activity_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "standard_site_documents": {
+      "name": "standard_site_documents",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "documentUri": {
+          "name": "documentUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "documentRkey": {
+          "name": "documentRkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "documentCid": {
+          "name": "documentCid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bskyPostUri": {
+          "name": "bskyPostUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bskyPostCid": {
+          "name": "bskyPostCid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(strftime('%s', 'now') as int))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779806126566,
       "tag": "0001_broken_mac_gargan",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1780003416801,
+      "tag": "0002_black_human_fly",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:e2e": "playwright test",
-    "drizzle:migration:generate": "drizzle-kit generate:sqlite --out ./migrations --schema ./src/lib/database/schema.ts",
+    "drizzle:migration:generate": "drizzle-kit generate",
+    "standard-site:create-publication": "vite-node scripts/standard-site/create-publication.ts",
+    "standard-site:publish-page": "vite-node scripts/standard-site/publish-page.ts",
     "prepare": "husky"
   },
   "prettier": {
@@ -47,6 +49,7 @@
     "@astrojs/preact": "^4.0.0",
     "@astrojs/tailwind": "^5.1.3",
     "@atproto/api": "^0.13.19",
+    "@bryanguffey/astro-standard-site": "^1.0.3",
     "@libsql/client": "^0.14.0",
     "@netlify/functions": "^3.0.0",
     "@react-hookz/web": "^24.0.4",
@@ -94,7 +97,6 @@
     "tailwindcss": "^3.4.16",
     "theme-change": "^2.5.0",
     "ts-dedent": "^2.2.0",
-    "ts-node": "^10.9.2",
     "unist-util-visit": "^5.1.0",
     "vite-plugin-webfont-dl": "^3.10.4",
     "zod": "^3.23.8"
@@ -128,6 +130,7 @@
     "prettier": "^3.5.0",
     "prettier-plugin-astro": "^0.14.1",
     "simple-git": "^3.27.0",
+    "vite-node": "^6.0.0",
     "vitest": "^2.1.8"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,28 +9,31 @@ importers:
     dependencies:
       '@astro-community/astro-embed-youtube':
         specifier: ^0.5.6
-        version: 0.5.6(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
+        version: 0.5.6(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
       '@astrojs/markdown-remark':
         specifier: ^6.1.0
         version: 6.1.0
       '@astrojs/mdx':
         specifier: ^4.0.8
-        version: 4.0.8(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
+        version: 4.0.8(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
       '@astrojs/netlify':
         specifier: ^6.1.0
-        version: 6.1.0(@types/node@22.10.1)(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(jiti@2.4.1)(rollup@4.34.6)(yaml@2.9.0)
+        version: 6.1.0(@types/node@22.10.1)(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(yaml@2.9.0)
       '@astrojs/partytown':
         specifier: ^2.1.2
         version: 2.1.2
       '@astrojs/preact':
         specifier: ^4.0.0
-        version: 4.0.0(@babel/core@7.26.0)(@types/node@22.10.1)(jiti@2.4.1)(preact@10.25.1)(yaml@2.9.0)
+        version: 4.0.0(@babel/core@7.26.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(preact@10.25.1)(yaml@2.9.0)
       '@astrojs/tailwind':
         specifier: ^5.1.3
-        version: 5.1.3(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
+        version: 5.1.3(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
       '@atproto/api':
         specifier: ^0.13.19
         version: 0.13.19
+      '@bryanguffey/astro-standard-site':
+        specifier: ^1.0.3
+        version: 1.0.3(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -45,7 +48,7 @@ importers:
         version: 0.5.15(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))
       astro:
         specifier: ^5.2.5
-        version: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+        version: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
       astro-seo:
         specifier: ^0.8.4
         version: 0.8.4(prettier-plugin-astro@0.14.1)(prettier@3.5.0)(typescript@5.7.2)
@@ -172,22 +175,19 @@ importers:
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.10.1)(typescript@5.7.2)
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
       vite-plugin-webfont-dl:
         specifier: ^3.10.4
-        version: 3.10.4(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0))
+        version: 3.10.4(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0))
       zod:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
       '@astro-notion/loader':
         specifier: ^1.1.2
-        version: 1.1.2(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
+        version: 1.1.2(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))
       '@eslint/eslintrc':
         specifier: ^3.2.0
         version: 3.2.0
@@ -269,9 +269,12 @@ importers:
       simple-git:
         specifier: ^3.27.0
         version: 3.27.0
+      vite-node:
+        specifier: ^6.0.0
+        version: 6.0.0(@types/node@22.10.1)(esbuild@0.19.12)(jiti@2.4.1)(yaml@2.9.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@22.10.1)(jsdom@25.0.1)
+        version: 2.1.8(@types/node@22.10.1)(jsdom@25.0.1)(lightningcss@1.32.0)
 
 packages:
   '@alloc/quick-lru@5.2.0':
@@ -426,10 +429,40 @@ packages:
         integrity: sha512-rLWQBZaOIk3ds1Fx9CwrdyX3X2GbdSEvVJ9mdSPNX40joiEaE1ljGMOcziFipbvZacXynozE4E0Sb1CgOhzfmA==,
       }
 
+  '@atproto/api@0.15.27':
+    resolution:
+      {
+        integrity: sha512-ok/WGafh1nz4t8pEQGtAF/32x2E2VDWU4af6BajkO5Gky2jp2q6cv6aB2A5yuvNNcc3XkYMYipsqVHVwLPMF9g==,
+      }
+
   '@atproto/common-web@0.3.1':
     resolution:
       {
         integrity: sha512-N7wiTnus5vAr+lT//0y8m/FaHHLJ9LpGuEwkwDAeV3LCiPif4m/FS8x/QOYrx1PdZQwKso95RAPzCGWQBH5j6Q==,
+      }
+
+  '@atproto/common-web@0.4.21':
+    resolution:
+      {
+        integrity: sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==,
+      }
+
+  '@atproto/lex-data@0.0.15':
+    resolution:
+      {
+        integrity: sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==,
+      }
+
+  '@atproto/lex-json@0.0.16':
+    resolution:
+      {
+        integrity: sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==,
+      }
+
+  '@atproto/lexicon@0.4.14':
+    resolution:
+      {
+        integrity: sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==,
       }
 
   '@atproto/lexicon@0.4.3':
@@ -438,16 +471,40 @@ packages:
         integrity: sha512-lFVZXe1S1pJP0dcxvJuHP3r/a+EAIBwwU7jUK+r8iLhIja+ml6NmYv8KeFHmIJATh03spEQ9s02duDmFVdCoXg==,
       }
 
+  '@atproto/lexicon@0.6.2':
+    resolution:
+      {
+        integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==,
+      }
+
   '@atproto/syntax@0.3.1':
     resolution:
       {
         integrity: sha512-fzW0Mg1QUOVCWUD3RgEsDt6d1OZ6DdFmbKcDdbzUfh0t4rhtRAC05KbZYmxuMPWDAiJ4BbbQ5dkAc/mNypMXkw==,
       }
 
+  '@atproto/syntax@0.4.3':
+    resolution:
+      {
+        integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==,
+      }
+
+  '@atproto/syntax@0.5.4':
+    resolution:
+      {
+        integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==,
+      }
+
   '@atproto/xrpc@0.6.4':
     resolution:
       {
         integrity: sha512-9ZAJ8nsXTqC4XFyS0E1Wlg7bAvonhXQNQ3Ocs1L1LIwFLXvsw/4fNpIHXxvXvqTCVeyHLbImOnE9UiO1c/qIYA==,
+      }
+
+  '@atproto/xrpc@0.7.7':
+    resolution:
+      {
+        integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==,
       }
 
   '@babel/code-frame@7.26.2':
@@ -606,6 +663,14 @@ packages:
       }
     engines: { node: '>=6.9.0' }
 
+  '@bryanguffey/astro-standard-site@1.0.3':
+    resolution:
+      {
+        integrity: sha512-+4//yk8rRD3ZfC9uOKY7OHu7Shm5qMZSgFTIcDs079hcoV42yF8mK8O0AI6QMFb7iMCPqN9rO+leP+PMEEmR3A==,
+      }
+    peerDependencies:
+      astro: ^5.0.0
+
   '@bugsnag/browser@7.25.0':
     resolution:
       {
@@ -755,10 +820,28 @@ packages:
         integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
       }
 
+  '@emnapi/core@1.10.0':
+    resolution:
+      {
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
+  '@emnapi/runtime@1.10.0':
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+      }
+
   '@emnapi/runtime@1.3.1':
     resolution:
       {
         integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==,
+      }
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
   '@esbuild-kit/core-utils@3.3.2':
@@ -2781,6 +2864,15 @@ packages:
         integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==,
       }
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution:
+      {
+        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+      }
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@neon-rs/load@0.0.4':
     resolution:
       {
@@ -3249,6 +3341,12 @@ packages:
         integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==,
       }
 
+  '@oxc-project/types@0.132.0':
+    resolution:
+      {
+        integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==,
+      }
+
   '@parcel/watcher-android-arm64@2.5.0':
     resolution:
       {
@@ -3496,6 +3594,146 @@ packages:
     peerDependenciesMeta:
       js-cookie:
         optional: true
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution:
+      {
+        integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution:
+      {
+        integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution:
+      {
+        integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution:
+      {
+        integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution:
+      {
+        integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution:
+      {
+        integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution:
+      {
+        integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution:
+      {
+        integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution:
+      {
+        integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution:
+      {
+        integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution:
+      {
+        integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution:
+      {
+        integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution:
+      {
+        integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution:
+      {
+        integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution:
+      {
+        integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution:
+      {
+        integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
+      }
 
   '@rollup/pluginutils@4.2.1':
     resolution:
@@ -3957,6 +4195,12 @@ packages:
     resolution:
       {
         integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==,
+      }
+
+  '@tybys/wasm-util@0.10.2':
+    resolution:
+      {
+        integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
       }
 
   '@types/acorn@4.0.6':
@@ -5220,6 +5464,13 @@ packages:
         integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
       }
     engines: { node: '>=8' }
+
+  cac@7.0.0:
+    resolution:
+      {
+        integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==,
+      }
+    engines: { node: '>=20.19.0' }
 
   cacheable-lookup@7.0.0:
     resolution:
@@ -6696,6 +6947,12 @@ packages:
         integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==,
       }
 
+  es-module-lexer@2.1.0:
+    resolution:
+      {
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+      }
+
   es-object-atoms@1.1.2:
     resolution:
       {
@@ -7510,6 +7767,18 @@ packages:
       {
         integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==,
       }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: '>=12.0.0' }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -9388,6 +9657,112 @@ packages:
         integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==,
       }
 
+  lightningcss-android-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+
   lilconfig@3.1.3:
     resolution:
       {
@@ -10455,6 +10830,14 @@ packages:
         integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==,
       }
 
+  nanoid@3.3.12:
+    resolution:
+      {
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
   nanoid@3.3.8:
     resolution:
       {
@@ -10800,6 +11183,12 @@ packages:
         integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==,
       }
     engines: { node: '>= 0.4' }
+
+  obug@2.1.1:
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
 
   ofetch@1.4.1:
     resolution:
@@ -11303,6 +11692,12 @@ packages:
         integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
       }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
   pathval@2.0.0:
     resolution:
       {
@@ -11526,6 +11921,13 @@ packages:
     resolution:
       {
         integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  postcss@8.5.15:
+    resolution:
+      {
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -12358,6 +12760,14 @@ packages:
       {
         integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==,
       }
+    hasBin: true
+
+  rolldown@1.0.2:
+    resolution:
+      {
+        integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
 
   rollup@4.28.1:
@@ -13304,6 +13714,13 @@ packages:
       }
     engines: { node: '>=18' }
 
+  tinyglobby@0.2.16:
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
+      }
+    engines: { node: '>=12.0.0' }
+
   tinypool@1.0.2:
     resolution:
       {
@@ -13697,6 +14114,12 @@ packages:
     resolution:
       {
         integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==,
+      }
+
+  unicode-segmenter@0.14.5:
+    resolution:
+      {
+        integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==,
       }
 
   unicode-trie@2.0.0:
@@ -14184,6 +14607,14 @@ packages:
     engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
 
+  vite-node@6.0.0:
+    resolution:
+      {
+        integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
   vite-plugin-webfont-dl@3.10.4:
     resolution:
       {
@@ -14296,6 +14727,52 @@ packages:
       less:
         optional: true
       lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.14:
+    resolution:
+      {
+        integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -14977,16 +15454,16 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@astro-community/astro-embed-youtube@0.5.6(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
+  '@astro-community/astro-embed-youtube@0.5.6(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
     dependencies:
-      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
       lite-youtube-embed: 0.3.3
 
-  '@astro-notion/loader@1.1.2(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
+  '@astro-notion/loader@1.1.2(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
     dependencies:
       '@jsdevtools/rehype-toc': 3.0.2
       '@notionhq/client': 2.3.0
-      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
       fs-extra: 11.3.5
       kleur: 4.1.5
       notion-rehype-k: 1.1.6
@@ -15068,12 +15545,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.0.8(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
+  '@astrojs/mdx@4.0.8(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.1.0
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       acorn: 8.14.0
-      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.4
@@ -15087,15 +15564,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@6.1.0(@types/node@22.10.1)(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(jiti@2.4.1)(rollup@4.34.6)(yaml@2.9.0)':
+  '@astrojs/netlify@6.1.0(@types/node@22.10.1)(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/underscore-redirects': 0.6.0
       '@netlify/functions': 2.8.2
       '@vercel/nft': 0.29.1(rollup@4.34.6)
-      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
       esbuild: 0.24.2
-      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
+      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - encoding
@@ -15117,16 +15594,16 @@ snapshots:
       '@builder.io/partytown': 0.10.2
       mrmime: 2.0.0
 
-  '@astrojs/preact@4.0.0(@babel/core@7.26.0)(@types/node@22.10.1)(jiti@2.4.1)(preact@10.25.1)(yaml@2.9.0)':
+  '@astrojs/preact@4.0.0(@babel/core@7.26.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(preact@10.25.1)(yaml@2.9.0)':
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-development': 7.25.9(@babel/core@7.26.0)
-      '@preact/preset-vite': 2.8.2(@babel/core@7.26.0)(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0))
+      '@preact/preset-vite': 2.8.2(@babel/core@7.26.0)(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0))
       '@preact/signals': 1.3.1(preact@10.25.1)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.26.0)
       preact: 10.25.1
       preact-render-to-string: 6.5.11(preact@10.25.1)
-      vite: 6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
+      vite: 6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -15146,9 +15623,9 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/tailwind@5.1.3(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))':
+  '@astrojs/tailwind@5.1.3(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))':
     dependencies:
-      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
       autoprefixer: 10.4.20(postcss@8.4.49)
       postcss: 8.4.49
       postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
@@ -15185,12 +15662,50 @@ snapshots:
       tlds: 1.255.0
       zod: 3.23.8
 
+  '@atproto/api@0.15.27':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/lexicon': 0.4.14
+      '@atproto/syntax': 0.4.3
+      '@atproto/xrpc': 0.7.7
+      await-lock: 2.2.2
+      multiformats: 9.9.0
+      tlds: 1.255.0
+      zod: 3.24.1
+
   '@atproto/common-web@0.3.1':
     dependencies:
       graphemer: 1.4.0
       multiformats: 9.9.0
       uint8arrays: 3.0.0
-      zod: 3.23.8
+      zod: 3.24.1
+
+  '@atproto/common-web@0.4.21':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      '@atproto/lex-json': 0.0.16
+      '@atproto/syntax': 0.5.4
+      zod: 3.24.1
+
+  '@atproto/lex-data@0.0.15':
+    dependencies:
+      multiformats: 9.9.0
+      tslib: 2.8.1
+      uint8arrays: 3.0.0
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.0.16':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.4.14':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.4.3
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.24.1
 
   '@atproto/lexicon@0.4.3':
     dependencies:
@@ -15198,14 +15713,35 @@ snapshots:
       '@atproto/syntax': 0.3.1
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
-      zod: 3.23.8
+      zod: 3.24.1
+
+  '@atproto/lexicon@0.6.2':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.5.4
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.24.1
 
   '@atproto/syntax@0.3.1': {}
+
+  '@atproto/syntax@0.4.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/syntax@0.5.4':
+    dependencies:
+      tslib: 2.8.1
 
   '@atproto/xrpc@0.6.4':
     dependencies:
       '@atproto/lexicon': 0.4.3
-      zod: 3.23.8
+      zod: 3.24.1
+
+  '@atproto/xrpc@0.7.7':
+    dependencies:
+      '@atproto/lexicon': 0.6.2
+      zod: 3.24.1
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -15340,6 +15876,12 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@bryanguffey/astro-standard-site@1.0.3(astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0))':
+    dependencies:
+      '@atproto/api': 0.15.27
+      astro: 5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0)
+      zod: 3.24.1
+
   '@bugsnag/browser@7.25.0':
     dependencies:
       '@bugsnag/core': 7.25.0
@@ -15432,7 +15974,23 @@ snapshots:
 
   '@emmetio/stream-reader@2.2.0': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -16286,6 +16844,13 @@ snapshots:
       - acorn
       - supports-color
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@neon-rs/load@0.0.4': {}
 
   '@netlify/binary-info@1.0.0': {}
@@ -16599,7 +17164,7 @@ snapshots:
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
       yargs: 17.7.2
-      zod: 3.23.8
+      zod: 3.24.1
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -16747,6 +17312,8 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oxc-project/types@0.132.0': {}
+
   '@parcel/watcher-android-arm64@2.5.0':
     optional: true
 
@@ -16833,12 +17400,12 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@preact/preset-vite@2.8.2(@babel/core@7.26.0)(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0))':
+  '@preact/preset-vite@2.8.2(@babel/core@7.26.0)(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-development': 7.25.9(@babel/core@7.26.0)
-      '@prefresh/vite': 2.4.6(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0))
+      '@prefresh/vite': 2.4.6(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0))
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.26.0)
       debug: 4.4.0(supports-color@9.4.0)
@@ -16848,7 +17415,7 @@ snapshots:
       resolve: 1.22.8
       source-map: 0.7.4
       stack-trace: 1.0.0-pre2
-      vite: 6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
+      vite: 6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -16868,7 +17435,7 @@ snapshots:
 
   '@prefresh/utils@1.2.0': {}
 
-  '@prefresh/vite@2.4.6(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0))':
+  '@prefresh/vite@2.4.6(preact@10.25.1)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@prefresh/babel-plugin': 0.5.1
@@ -16876,7 +17443,7 @@ snapshots:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.25.1
-      vite: 6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
+      vite: 6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16887,6 +17454,57 @@ snapshots:
       '@react-hookz/deep-equal': 1.0.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -17105,6 +17723,11 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -17346,13 +17969,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.14
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.1)
+      vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -17706,7 +18329,7 @@ snapshots:
       - prettier-plugin-astro
       - typescript
 
-  astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0):
+  astro@5.2.5(@netlify/blobs@8.1.0)(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(rollup@4.34.6)(typescript@5.7.2)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.5.1
@@ -17758,8 +18381,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.14.4(@netlify/blobs@8.1.0)
       vfile: 6.0.3
-      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
-      vitefu: 1.0.5(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0))
+      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.0.5(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -18024,6 +18647,8 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cac@7.0.0: {}
 
   cacheable-lookup@7.0.0: {}
 
@@ -18753,6 +19378,8 @@ snapshots:
 
   es-module-lexer@1.6.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -19476,6 +20103,10 @@ snapshots:
       pend: 1.2.0
 
   fdir@6.4.2(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
@@ -20686,6 +21317,55 @@ snapshots:
       process-warning: 3.0.0
       set-cookie-parser: 2.7.1
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.3
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -21533,6 +22213,8 @@ snapshots:
   nan@2.22.0:
     optional: true
 
+  nanoid@3.3.12: {}
+
   nanoid@3.3.8: {}
 
   napi-build-utils@1.0.2: {}
@@ -21858,6 +22540,8 @@ snapshots:
 
   object-inspect@1.13.3: {}
 
+  obug@2.1.1: {}
+
   ofetch@1.4.1:
     dependencies:
       destr: 2.0.3
@@ -22144,6 +22828,8 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
   pathval@2.0.0: {}
 
   peek-readable@5.3.1: {}
@@ -22272,6 +22958,12 @@ snapshots:
   postcss@8.4.49:
     dependencies:
       nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -22841,6 +23533,27 @@ snapshots:
   rimraf@5.0.10:
     dependencies:
       glob: 10.4.5
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
 
   rollup@4.28.1:
     dependencies:
@@ -23491,6 +24204,11 @@ snapshots:
 
   tinyexec@1.1.2: {}
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
@@ -23671,6 +24389,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       unicode-trie: 2.0.0
+
+  unicode-segmenter@0.14.5: {}
 
   unicode-trie@2.0.0:
     dependencies:
@@ -23980,13 +24700,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@2.1.8(@types/node@22.10.1):
+  vite-node@2.1.8(@types/node@22.10.1)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.1)
+      vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23998,17 +24718,38 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-webfont-dl@3.10.4(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)):
+  vite-node@6.0.0(@types/node@22.10.1)(esbuild@0.19.12)(jiti@2.4.1)(yaml@2.9.0):
+    dependencies:
+      cac: 7.0.0
+      es-module-lexer: 2.1.0
+      obug: 2.1.1
+      pathe: 2.0.3
+      vite: 8.0.14(@types/node@22.10.1)(esbuild@0.19.12)(jiti@2.4.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vite-plugin-webfont-dl@3.10.4(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       axios: 1.7.9
       clean-css: 5.3.3
       flat-cache: 6.1.6
       picocolors: 1.1.1
-      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
+      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - debug
 
-  vite@5.4.11(@types/node@22.10.1):
+  vite@5.4.11(@types/node@22.10.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
@@ -24016,8 +24757,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.1
       fsevents: 2.3.3
+      lightningcss: 1.32.0
 
-  vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0):
+  vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -24026,9 +24768,10 @@ snapshots:
       '@types/node': 22.10.1
       fsevents: 2.3.3
       jiti: 2.4.1
+      lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0):
+  vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
@@ -24037,16 +24780,31 @@ snapshots:
       '@types/node': 22.10.1
       fsevents: 2.3.3
       jiti: 2.4.1
+      lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vitefu@1.0.5(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)):
+  vite@8.0.14(@types/node@22.10.1)(esbuild@0.19.12)(jiti@2.4.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
     optionalDependencies:
-      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(yaml@2.9.0)
+      '@types/node': 22.10.1
+      esbuild: 0.19.12
+      fsevents: 2.3.3
+      jiti: 2.4.1
+      yaml: 2.9.0
 
-  vitest@2.1.8(@types/node@22.10.1)(jsdom@25.0.1):
+  vitefu@1.0.5(vite@6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 6.1.0(@types/node@22.10.1)(jiti@2.4.1)(lightningcss@1.32.0)(yaml@2.9.0)
+
+  vitest@2.1.8(@types/node@22.10.1)(jsdom@25.0.1)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -24062,8 +24820,8 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.1)
-      vite-node: 2.1.8(@types/node@22.10.1)
+      vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.32.0)
+      vite-node: 2.1.8(@types/node@22.10.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.1

--- a/scripts/standard-site/create-publication.ts
+++ b/scripts/standard-site/create-publication.ts
@@ -1,0 +1,68 @@
+/**
+ * One-time (re-runnable) setup: publishes the `site.standard.publication`
+ * record to ATProto and writes the resulting DID + rkey to Netlify so
+ * production builds can publish documents and serve the verification endpoint.
+ *
+ * Run with:  pnpm standard-site:create-publication
+ * Requires BLUESKY_USERNAME and BLUESKY_PASSWORD in the environment, and the
+ * netlify CLI to be linked (`netlify link`).
+ */
+import { execFileSync } from 'node:child_process'
+import { getPublisher } from '../../src/lib/standardSite'
+import config from '../../src/config'
+
+async function main() {
+  const username =
+    import.meta.env.BLUESKY_USERNAME || process.env.BLUESKY_USERNAME
+  const appPassword =
+    import.meta.env.BLUESKY_PASSWORD || process.env.BLUESKY_PASSWORD
+
+  if (!username || !appPassword) {
+    console.error(
+      'Missing credentials: set BLUESKY_USERNAME and BLUESKY_PASSWORD (a Bluesky app password).'
+    )
+    process.exit(1)
+  }
+
+  const publisher = await getPublisher()
+  const result = await publisher.publishPublication({
+    name: config.title,
+    url: config.url,
+    description: config.description,
+  })
+
+  const did = publisher.getDid()
+  const publicationRkey = result.uri.split('/').pop() as string
+
+  console.log('\nPublication record published:')
+  console.log('  AT-URI:', result.uri)
+  console.log('  STANDARD_SITE_DID:', did)
+  console.log('  STANDARD_SITE_PUBLICATION_RKEY:', publicationRkey)
+
+  const vars: Array<[string, string]> = [
+    ['STANDARD_SITE_DID', did],
+    ['STANDARD_SITE_PUBLICATION_RKEY', publicationRkey],
+  ]
+
+  for (const [key, value] of vars) {
+    try {
+      execFileSync('netlify', ['env:set', key, value], { stdio: 'inherit' })
+      console.log(`✓ Set Netlify env ${key}`)
+    } catch (e) {
+      console.error(
+        `✗ Could not set Netlify env ${key} — set it manually. (${
+          (e as Error).message
+        })`
+      )
+    }
+  }
+
+  console.log(
+    '\nDone. Redeploy so the .well-known endpoint and document publishing pick up the new env vars.'
+  )
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/standard-site/publish-page.ts
+++ b/scripts/standard-site/publish-page.ts
@@ -1,0 +1,79 @@
+/**
+ * Manually publish hand-made static HTML pages (e.g. src/pages/horses.html) to
+ * standard.site as ATProto documents.
+ *
+ * Run with:  pnpm standard-site:publish-page src/pages/horses.html [more.html ...]
+ * Requires BLUESKY_USERNAME, BLUESKY_PASSWORD, and STANDARD_SITE_DID.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { JSDOM } from 'jsdom'
+import { isConfigured, publishStaticPage } from '../../src/lib/standardSite'
+
+/** Map a file like src/pages/saturdays/index.html to the route /saturdays/. */
+function fileToRoutePath(file: string): string {
+  let rel = file.replace(/\\/g, '/').replace(/^.*?src\/pages\//, '')
+  rel = rel.replace(/\.html$/, '').replace(/(^|\/)index$/, '$1')
+  if (!rel.startsWith('/')) rel = `/${rel}`
+  return rel
+}
+
+async function publishFile(file: string) {
+  const html = readFileSync(file, 'utf-8')
+  const doc = new JSDOM(html).window.document
+
+  const title =
+    doc.querySelector('title')?.textContent?.trim() ||
+    doc.querySelector('h1')?.textContent?.trim() ||
+    path.basename(file)
+  const description =
+    doc
+      .querySelector('meta[name="description"]')
+      ?.getAttribute('content')
+      ?.trim() || undefined
+
+  doc.querySelectorAll('script, style, noscript').forEach((el) => el.remove())
+  const textContent = (doc.body?.textContent ?? '').replace(/\s+/g, ' ').trim()
+
+  const routePath = fileToRoutePath(file)
+  const row = await publishStaticPage({
+    path: routePath,
+    title,
+    description,
+    body: textContent,
+  })
+
+  console.log(`✓ ${file} → ${routePath}`)
+  if (row) console.log(`   ${row.documentUri}`)
+}
+
+async function main() {
+  const files = process.argv.slice(2)
+
+  if (files.length === 0) {
+    console.error(
+      'Usage: pnpm standard-site:publish-page <file.html> [<file.html> ...]'
+    )
+    process.exit(1)
+  }
+
+  if (!isConfigured()) {
+    console.error(
+      'standard.site is not configured. Set BLUESKY_USERNAME, BLUESKY_PASSWORD, and STANDARD_SITE_DID.'
+    )
+    process.exit(1)
+  }
+
+  for (const file of files) {
+    try {
+      await publishFile(file)
+    } catch (e) {
+      console.error(`✗ Failed to publish ${file}:`, e)
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/components/Post/Comments.astro
+++ b/src/components/Post/Comments.astro
@@ -1,0 +1,52 @@
+---
+import BlueskyComments from '@bryanguffey/astro-standard-site/components/Comments.astro'
+import config from '../../config'
+
+interface Props {
+  /** Site-absolute path of the post, e.g. /blog/my-post/ */
+  canonicalPath: string
+  /** AT-URI of the Bluesky announcement post, if one exists. */
+  bskyPostUri?: string
+}
+
+const { canonicalPath, bskyPostUri } = Astro.props
+const canonicalUrl = config.url + canonicalPath
+---
+
+<footer>
+  {
+    /* Bluesky-powered comments via standard.site, only when there's a post to thread under. */
+  }
+  {
+    bskyPostUri && (
+      <BlueskyComments
+        bskyPostUri={bskyPostUri}
+        canonicalUrl={canonicalUrl}
+        title="✨💬✨ Comments from Bluesky"
+        class="standard-site-comments"
+      />
+    )
+  }
+
+  <script
+    is:inline
+    src="https://utteranc.es/client.js"
+    repo="eligundry/eligundry.com"
+    issue-term="pathname"
+    label="✨💬✨  Blog"
+    theme="preferred-color-scheme"
+    crossorigin="anonymous"
+    async></script>
+</footer>
+
+<style is:global>
+  /* Map standard.site's CSS variables onto the site's daisyUI theme tokens. */
+  .standard-site-comments {
+    --color-border-soft: var(--fallback-bc, oklch(var(--bc) / 0.2));
+    --color-text-primary: oklch(var(--bc));
+    --color-text-secondary: oklch(var(--bc) / 0.8);
+    --color-text-muted: oklch(var(--bc) / 0.6);
+    --color-text-link: oklch(var(--p));
+    --color-bg-elevated: oklch(var(--b2));
+  }
+</style>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -3,6 +3,8 @@ import type { CollectionEntry } from 'astro:content'
 import * as dateFns from 'date-fns'
 import BaseLayout from './Layout.astro'
 import EmojiText from '../components/EmojiText.astro'
+import Comments from '../components/Post/Comments.astro'
+import { getVerificationLinkTag } from '../lib/standardSite'
 
 interface Props {
   collection: string
@@ -16,6 +18,10 @@ interface Props {
     readingTime: number
   }>
   fancyBackgroundPoints?: number
+  /** standard.site document record key, for the verification <link> tag. */
+  documentRkey?: string
+  /** Bluesky announcement post URI, for federated comments. */
+  bskyPostUri?: string
 }
 
 const {
@@ -25,10 +31,13 @@ const {
   collection,
   showComments,
   fancyBackgroundPoints,
+  documentRkey,
+  bskyPostUri,
 } = Astro.props
 const { title, description, cover, date } = frontmatter
 const { modified, readingTime = 0 } = remarkPluginFrontmatter
 const url = `/${collection}/${slug}/`
+const verificationLinkTag = getVerificationLinkTag(documentRkey)
 ---
 
 <style>
@@ -46,6 +55,11 @@ const url = `/${collection}/${slug}/`
   remarkPluginFrontmatter={remarkPluginFrontmatter}
   fancyBackgroundPoints={fancyBackgroundPoints}
 >
+  {
+    verificationLinkTag && (
+      <Fragment slot="head" set:html={verificationLinkTag} />
+    )
+  }
   <article
     class="paper prose"
     itemscope
@@ -113,21 +127,6 @@ const url = `/${collection}/${slug}/`
     <div itemprop="text" class="post-body">
       <slot />
     </div>
-    {
-      showComments && (
-        <footer>
-          <script
-            is:inline
-            src="https://utteranc.es/client.js"
-            repo="eligundry/eligundry.com"
-            issue-term="pathname"
-            label="✨💬✨  Blog"
-            theme="preferred-color-scheme"
-            crossorigin="anonymous"
-            async
-          />
-        </footer>
-      )
-    }
+    {showComments && <Comments canonicalPath={url} bskyPostUri={bskyPostUri} />}
   </article>
 </BaseLayout>

--- a/src/lib/bluesky.ts
+++ b/src/lib/bluesky.ts
@@ -14,14 +14,17 @@ async function getAgent() {
   return agent
 }
 
-async function sendPost(text: string, extra?: any) {
+async function sendPost(
+  text: string,
+  extra?: any
+): Promise<{ uri: string; cid: string }> {
   const agent = await getAgent()
   const richText = new RichText({
     text: dedent(trim(text, ' \n')),
   })
   await richText.detectFacets(agent)
 
-  await agent.post({
+  return agent.post({
     ...extra,
     text: richText.text,
     facets: richText.facets,

--- a/src/lib/database/index.ts
+++ b/src/lib/database/index.ts
@@ -3,8 +3,12 @@ import { createClient } from '@libsql/client/web'
 
 export * from './schema'
 
+// Prefer Vite's import.meta.env (Astro runtime/build) but fall back to
+// process.env so standalone scripts run via vite-node can connect too.
 export const client = createClient({
-  url: import.meta.env.SECRET_TURSO_DB_URL,
-  authToken: import.meta.env.SECRET_TURSO_DB_AUTH_TOKEN,
+  url: import.meta.env.SECRET_TURSO_DB_URL ?? process.env.SECRET_TURSO_DB_URL,
+  authToken:
+    import.meta.env.SECRET_TURSO_DB_AUTH_TOKEN ??
+    process.env.SECRET_TURSO_DB_AUTH_TOKEN,
 })
 export const db = drizzle(client)

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -44,3 +44,24 @@ export const daylioEntryActivities = sqliteTable(
   },
   (table) => [primaryKey({ columns: [table.time, table.activity] })]
 )
+
+// Tracks content that has been published to ATProto via standard.site so we
+// don't re-publish unchanged documents on every build. Keyed by a stable path
+// (e.g. /blog/<slug>/, /blog/links/<slug>/, /feelings#<slug>, /horses).
+export const standardSiteDocuments = sqliteTable('standard_site_documents', {
+  path: text('path').primaryKey(),
+  kind: text('kind', { enum: ['blog', 'link', 'feeling', 'page'] }).notNull(),
+  documentUri: text('documentUri').notNull(),
+  documentRkey: text('documentRkey').notNull(),
+  documentCid: text('documentCid').notNull(),
+  // The Bluesky announcement post that comments are threaded under (blog/link
+  // posts only). Null for content we don't announce (e.g. feelings).
+  bskyPostUri: text('bskyPostUri'),
+  bskyPostCid: text('bskyPostCid'),
+  // sha256 of title + body; when it changes we update the ATProto record.
+  contentHash: text('contentHash').notNull(),
+  publishedAt: integer('publishedAt', { mode: 'timestamp' }).default(
+    timestampSQL
+  ),
+  updatedAt: integer('updatedAt', { mode: 'timestamp' }).default(timestampSQL),
+})

--- a/src/lib/standardSite.ts
+++ b/src/lib/standardSite.ts
@@ -1,0 +1,366 @@
+import crypto from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import * as dateFns from 'date-fns'
+import {
+  StandardSitePublisher,
+  transformContent,
+  generateDocumentLinkTag,
+  getPublicationAtUri,
+} from '@bryanguffey/astro-standard-site'
+import { db, standardSiteDocuments } from './database'
+import blueSky from './bluesky'
+import daylio, { type DaylioEntry } from './daylio'
+import config from '../config'
+
+type StoredDocument = typeof standardSiteDocuments.$inferSelect
+
+// Only announce posts on Bluesky (for comments) if they were published within
+// this window. Without this, the first build would spam announcements for every
+// historical post. Older posts still get a standard.site document, just no
+// Bluesky comment thread.
+const ANNOUNCE_MAX_AGE_DAYS = 30
+// Cap how many *new* documents we publish per build so a first run doesn't try
+// to write years of feelings to ATProto in one go (rate limits / build time).
+// Remaining entries are picked up on subsequent builds (nightly + on new posts).
+const MAX_NEW_PER_BUILD = 100
+
+// Env vars must be referenced as static `import.meta.env.NAME` literals so
+// Astro/Vite can statically replace them at build time (dynamic indexing like
+// `import.meta.env[key]` is NOT replaced and would be undefined in the bundle).
+// `import.meta.env` is the source in Astro builds/SSR; `process.env` is the
+// fallback for standalone vite-node scripts, where import.meta.env is empty.
+const firstSet = (...values: Array<string | undefined>): string | undefined =>
+  values.find((value) => !!value)
+
+const identifier = firstSet(
+  import.meta.env.BLUESKY_USERNAME,
+  process.env.BLUESKY_USERNAME
+)
+const password = firstSet(
+  import.meta.env.BLUESKY_PASSWORD,
+  process.env.BLUESKY_PASSWORD
+)
+const did = firstSet(
+  import.meta.env.STANDARD_SITE_DID,
+  process.env.STANDARD_SITE_DID
+)
+const publicationRkey = firstSet(
+  import.meta.env.STANDARD_SITE_PUBLICATION_RKEY,
+  process.env.STANDARD_SITE_PUBLICATION_RKEY
+)
+
+/**
+ * Whether standard.site publishing is wired up. Gates every network action so
+ * builds without credentials (e.g. local dev, forks) silently skip publishing
+ * but can still render verification tags/comments from previously stored data.
+ */
+export function isConfigured(): boolean {
+  return Boolean(identifier && password && did)
+}
+
+let publisherPromise: Promise<StandardSitePublisher> | null = null
+
+/** Memoized, logged-in publisher shared across all page renders in a build. */
+export async function getPublisher(): Promise<StandardSitePublisher> {
+  if (!publisherPromise) {
+    publisherPromise = (async () => {
+      const publisher = new StandardSitePublisher({
+        identifier: identifier!,
+        password: password!,
+        ...(did && publicationRkey
+          ? { publication: getPublicationAtUri(did, publicationRkey) }
+          : {}),
+      })
+      await publisher.login()
+      return publisher
+    })()
+  }
+
+  return publisherPromise
+}
+
+const hashContent = (parts: Array<string | undefined>): string =>
+  crypto
+    .createHash('sha256')
+    .update(parts.map((p) => p ?? '').join('\n---\n'))
+    .digest('hex')
+
+export async function getStoredDocument(
+  path: string
+): Promise<StoredDocument | null> {
+  try {
+    const rows = await db
+      .select()
+      .from(standardSiteDocuments)
+      .where(eq(standardSiteDocuments.path, path))
+      .limit(1)
+    return rows[0] ?? null
+  } catch (e) {
+    console.error(`[standard-site] failed to read stored document ${path}:`, e)
+    return null
+  }
+}
+
+/** Returns the `<link rel="site.standard.document">` tag for a post's `<head>`. */
+export function getVerificationLinkTag(
+  documentRkey?: string | null
+): string | null {
+  if (!documentRkey || !did) return null
+  return generateDocumentLinkTag({ did, documentRkey })
+}
+
+interface PublishInput {
+  path: string
+  kind: (typeof standardSiteDocuments.$inferInsert)['kind']
+  title: string
+  body: string
+  description?: string
+  publishedAt: Date
+  updatedAt?: Date
+  tags?: string[]
+  /** Path used to build the canonical URL; defaults to `path`. */
+  canonicalPath?: string
+  /** Post a Bluesky announcement (for comment threading) on first publish. */
+  announce?: boolean
+}
+
+/**
+ * Publish (or update) a single standard.site document, deduping on a content
+ * hash so unchanged content is never re-published. Returns the stored row and
+ * whether a network write happened.
+ */
+async function publishDocument(
+  input: PublishInput,
+  preloadedExisting?: StoredDocument | null
+): Promise<{ row: StoredDocument | null; changed: boolean }> {
+  const canonicalPath = input.canonicalPath ?? input.path
+  const { markdown, textContent } = transformContent(input.body ?? '', {
+    siteUrl: config.url,
+    postPath: canonicalPath,
+  })
+  const contentHash = hashContent([input.title, input.description, markdown])
+
+  const existing =
+    preloadedExisting !== undefined
+      ? preloadedExisting
+      : await getStoredDocument(input.path)
+
+  // Without credentials we can't publish, but we still hand back whatever we
+  // stored previously so pages can render comments/verification tags.
+  if (!isConfigured()) {
+    return { row: existing, changed: false }
+  }
+
+  if (existing && existing.contentHash === contentHash) {
+    return { row: existing, changed: false }
+  }
+
+  const publisher = await getPublisher()
+
+  // Reuse an existing announcement post; otherwise create one for recent posts.
+  let bskyPostUri = existing?.bskyPostUri ?? null
+  let bskyPostCid = existing?.bskyPostCid ?? null
+  const recentEnoughToAnnounce =
+    dateFns.differenceInDays(new Date(), input.publishedAt) <=
+    ANNOUNCE_MAX_AGE_DAYS
+
+  if (input.announce && !bskyPostUri && recentEnoughToAnnounce) {
+    const url = config.url + canonicalPath
+    const res = await blueSky.sendPost(`${input.title}\n\n${url}`)
+    bskyPostUri = res.uri
+    bskyPostCid = res.cid
+  }
+
+  const docInput = {
+    site: config.url,
+    title: input.title,
+    publishedAt: input.publishedAt.toISOString(),
+    path: canonicalPath,
+    description: input.description,
+    updatedAt: input.updatedAt?.toISOString(),
+    tags: input.tags,
+    textContent,
+    content: {
+      $type: 'site.standard.content.markdown',
+      text: markdown,
+      version: '1.0',
+    },
+    ...(bskyPostUri && bskyPostCid
+      ? { bskyPostRef: { uri: bskyPostUri, cid: bskyPostCid } }
+      : {}),
+  }
+
+  const result = existing
+    ? await publisher.updateDocument(existing.documentRkey, docInput)
+    : await publisher.publishDocument(docInput)
+
+  const documentRkey = result.uri.split('/').pop() as string
+  const row: StoredDocument = {
+    path: input.path,
+    kind: input.kind,
+    documentUri: result.uri,
+    documentRkey,
+    documentCid: result.cid,
+    bskyPostUri,
+    bskyPostCid,
+    contentHash,
+    publishedAt: existing?.publishedAt ?? new Date(),
+    updatedAt: new Date(),
+  }
+
+  await db
+    .insert(standardSiteDocuments)
+    .values(row)
+    .onConflictDoUpdate({
+      target: standardSiteDocuments.path,
+      set: {
+        documentUri: row.documentUri,
+        documentRkey: row.documentRkey,
+        documentCid: row.documentCid,
+        bskyPostUri: row.bskyPostUri,
+        bskyPostCid: row.bskyPostCid,
+        contentHash: row.contentHash,
+        updatedAt: row.updatedAt,
+      },
+    })
+    .run()
+
+  return { row, changed: true }
+}
+
+export interface SyncResult {
+  documentRkey?: string
+  bskyPostUri?: string
+}
+
+const toSyncResult = (row: StoredDocument | null): SyncResult => ({
+  documentRkey: row?.documentRkey,
+  bskyPostUri: row?.bskyPostUri ?? undefined,
+})
+
+export async function syncBlogPost(args: {
+  slug: string
+  title: string
+  description: string
+  date: Date
+  updated?: Date
+  tags: string[]
+  body: string
+}): Promise<SyncResult> {
+  try {
+    const { row } = await publishDocument({
+      path: `/blog/${args.slug}/`,
+      kind: 'blog',
+      title: args.title,
+      description: args.description,
+      publishedAt: args.date,
+      updatedAt: args.updated,
+      tags: args.tags,
+      body: args.body,
+      announce: true,
+    })
+    return toSyncResult(row)
+  } catch (e) {
+    console.error(`[standard-site] failed to publish blog "${args.slug}":`, e)
+    return toSyncResult(await getStoredDocument(`/blog/${args.slug}/`))
+  }
+}
+
+export async function syncLinkPost(args: {
+  slug: string
+  title: string
+  description?: string
+  url?: string
+  date: Date
+  tags: string[]
+  body: string
+}): Promise<SyncResult> {
+  const path = `/blog/links/${args.slug}/`
+  // Notion link posts can have empty bodies; fall back to the blurb + the URL.
+  const body = args.body?.trim()
+    ? args.body
+    : [args.description, args.url].filter(Boolean).join('\n\n')
+
+  try {
+    const { row } = await publishDocument({
+      path,
+      kind: 'link',
+      title: args.title,
+      description: args.description,
+      publishedAt: args.date,
+      tags: args.tags,
+      body,
+      announce: true,
+    })
+    return toSyncResult(row)
+  } catch (e) {
+    console.error(`[standard-site] failed to publish link "${args.slug}":`, e)
+    return toSyncResult(await getStoredDocument(path))
+  }
+}
+
+/**
+ * Publish public Daylio feelings as standard.site documents, mirroring the
+ * /feelings.rss feed (all public entries, title via tweetPrefix, body = note).
+ * Capped per build to avoid a huge backfill burst; converges over later builds.
+ */
+export async function syncFeelings(entries: DaylioEntry[]): Promise<void> {
+  if (!isConfigured()) return
+
+  let existingByPath = new Map<string, StoredDocument>()
+  try {
+    const rows = await db
+      .select()
+      .from(standardSiteDocuments)
+      .where(eq(standardSiteDocuments.kind, 'feeling'))
+    existingByPath = new Map(rows.map((row) => [row.path, row]))
+  } catch (e) {
+    console.error('[standard-site] failed to load existing feelings:', e)
+    return
+  }
+
+  const now = new Date()
+  let published = 0
+
+  for (const entry of entries) {
+    if (published >= MAX_NEW_PER_BUILD) break
+
+    const path = `/feelings#${entry.slug}`
+    try {
+      const { changed } = await publishDocument(
+        {
+          path,
+          kind: 'feeling',
+          title: daylio.tweetPrefix(entry, now),
+          publishedAt: entry.time,
+          body: entry.note?.markdown ?? '',
+          announce: false,
+        },
+        existingByPath.get(path) ?? null
+      )
+      if (changed) published += 1
+    } catch (e) {
+      console.error(`[standard-site] failed to publish feeling ${path}:`, e)
+    }
+  }
+}
+
+/** Publish a single hand-made static HTML page (used by the manual CLI). */
+export async function publishStaticPage(args: {
+  path: string
+  title: string
+  description?: string
+  body: string
+  publishedAt?: Date
+}): Promise<StoredDocument | null> {
+  const { row } = await publishDocument({
+    path: args.path,
+    kind: 'page',
+    title: args.title,
+    description: args.description,
+    publishedAt: args.publishedAt ?? new Date(),
+    body: args.body,
+    announce: false,
+  })
+  return row
+}

--- a/src/pages/.well-known/site.standard.publication.ts
+++ b/src/pages/.well-known/site.standard.publication.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from 'astro'
+import { generatePublicationWellKnown } from '@bryanguffey/astro-standard-site'
+
+const did = import.meta.env.STANDARD_SITE_DID || process.env.STANDARD_SITE_DID
+const publicationRkey =
+  import.meta.env.STANDARD_SITE_PUBLICATION_RKEY ||
+  process.env.STANDARD_SITE_PUBLICATION_RKEY
+
+// Proves ownership of the standard.site publication to ATProto readers.
+// See https://standard.site/. Configured via STANDARD_SITE_* env vars, which
+// are produced by `pnpm standard-site:create-publication`.
+export const GET: APIRoute = () => {
+  if (!did || !publicationRkey) {
+    return new Response('standard.site publication is not configured.', {
+      status: 404,
+    })
+  }
+
+  return new Response(generatePublicationWellKnown({ did, publicationRkey }), {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-content-type-options': 'nosniff',
+    },
+  })
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection, type CollectionEntry } from 'astro:content'
 import PostLayout from '../../layouts/Post.astro'
 import { readingTimeToFancyBackgroundPoints } from '../../lib/utils'
 import { components } from '../../components/Post/components.astro'
+import { syncBlogPost, type SyncResult } from '../../lib/standardSite'
 
 interface Props {
   entry: CollectionEntry<'blog'>
@@ -21,6 +22,21 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props
 const { Content, remarkPluginFrontmatter } = await entry.render()
+
+// Publish to ATProto (standard.site) on production builds. Best-effort: any
+// failure is swallowed inside syncBlogPost so it never breaks the build.
+let standardSite: SyncResult = {}
+if (import.meta.env.PROD && !entry.data.draft) {
+  standardSite = await syncBlogPost({
+    slug: entry.slug,
+    title: entry.data.title,
+    description: entry.data.description,
+    date: entry.data.date,
+    updated: remarkPluginFrontmatter.modified,
+    tags: entry.data.tags,
+    body: entry.body,
+  })
+}
 ---
 
 <PostLayout
@@ -29,6 +45,8 @@ const { Content, remarkPluginFrontmatter } = await entry.render()
   frontmatter={entry.data}
   remarkPluginFrontmatter={remarkPluginFrontmatter}
   showComments
+  documentRkey={standardSite.documentRkey}
+  bskyPostUri={standardSite.bskyPostUri}
   fancyBackgroundPoints={readingTimeToFancyBackgroundPoints(
     remarkPluginFrontmatter.readingTime
   )}

--- a/src/pages/blog/links/[slug].astro
+++ b/src/pages/blog/links/[slug].astro
@@ -4,7 +4,13 @@ import * as dateFns from 'date-fns'
 import BaseLayout from '../../../layouts/Layout.astro'
 import EmojiText from '../../../components/EmojiText.astro'
 import LinkEmbed from '../../../components/LinkEmbed.astro'
+import Comments from '../../../components/Post/Comments.astro'
 import { getLinkPostDate } from '../../../content/links'
+import {
+  syncLinkPost,
+  getVerificationLinkTag,
+  type SyncResult,
+} from '../../../lib/standardSite'
 
 interface Props {
   entry: CollectionEntry<'links'>
@@ -25,12 +31,33 @@ const { Content } = await render(entry)
 const props = entry.data.properties
 const url = `/blog/links/${props.Slug}/`
 const date = getLinkPostDate(entry.data)
+
+// Publish link posts to ATProto (standard.site) on production builds, mirroring
+// how regular blog posts are handled. Best-effort and non-fatal.
+let standardSite: SyncResult = {}
+if (import.meta.env.PROD) {
+  standardSite = await syncLinkPost({
+    slug: props.Slug,
+    title: props.Title,
+    description: props.Description ?? undefined,
+    url: props.URL ?? undefined,
+    date,
+    tags: Array.isArray(props.Tags) ? props.Tags : [],
+    body: entry.body ?? '',
+  })
+}
+const verificationLinkTag = getVerificationLinkTag(standardSite.documentRkey)
 ---
 
 <BaseLayout
   title={props.Title}
   description={props.Description ?? props.URL ?? ''}
 >
+  {
+    verificationLinkTag && (
+      <Fragment slot="head" set:html={verificationLinkTag} />
+    )
+  }
   <article
     class="paper prose"
     itemscope
@@ -76,5 +103,6 @@ const date = getLinkPostDate(entry.data)
     <div itemprop="text">
       <Content />
     </div>
+    <Comments canonicalPath={url} bskyPostUri={standardSite.bskyPostUri} />
   </article>
 </BaseLayout>

--- a/src/pages/feelings.astro
+++ b/src/pages/feelings.astro
@@ -3,10 +3,18 @@ import Layout from '../layouts/Layout.astro'
 import DaylioEntry from '../components/DaylioEntry.astro'
 import DaylioChart from '../components/DaylioChart'
 import { getCollection } from 'astro:content'
+import { syncFeelings } from '../lib/standardSite'
 
-const entries = await getCollection('feelings').then((records) =>
-  records.map((record) => record.data).slice(0, 100)
+const allEntries = await getCollection('feelings').then((records) =>
+  records.map((record) => record.data)
 )
+const entries = allEntries.slice(0, 100)
+
+// Publish all public feelings to ATProto (standard.site) on production builds,
+// mirroring the /feelings.rss feed. Best-effort and capped per build.
+if (import.meta.env.PROD) {
+  await syncFeelings(allEntries)
+}
 ---
 
 <Layout


### PR DESCRIPTION
Publishes content to ATProto via @bryanguffey/astro-standard-site so it's
portable across standard.site readers (Leaflet, Pckt, etc.).

- src/lib/standardSite.ts: credential-agnostic publisher wrapper with
  content-hash dedupe, an announcement-age cutoff, and a per-build cap on
  feelings to avoid a huge backfill burst. Reads env via static
  import.meta.env literals (Astro build/SSR) with process.env fallback
  (vite-node scripts).
- standard_site_documents table (Drizzle) tracks published docs to avoid
  re-publishing unchanged content; migration 0002.
- Blog, Notion link, and feelings pages publish on production builds
  (best-effort, non-fatal, skipped without credentials). Feelings mirror
  the /feelings.rss feed.
- Shared Post/Comments.astro renders Bluesky-powered comments (standard.site)
  alongside the existing utteranc.es comments on blog and link posts.
- Per-document verification <link> tags + /.well-known/site.standard.publication
  endpoint.
- CLI scripts (run via vite-node): create-publication (publishes the
  publication record and writes STANDARD_SITE_* to Netlify) and publish-page
  (manually publish hand-made static HTML pages). Drop unused ts-node dep.