### PR TITLE
Fix standard.site blog publishing: coerce non-Date updatedAt

### DIFF
--- a/src/lib/standardSite.ts
+++ b/src/lib/standardSite.ts
@@ -115,13 +115,22 @@ interface PublishInput {
   title: string
   body: string
   description?: string
-  publishedAt: Date
-  updatedAt?: Date
+  // Accepts a Date, ISO string, or epoch — remark frontmatter (e.g. the
+  // git-last-modified date) can arrive as a string, so we coerce defensively.
+  publishedAt: Date | string | number
+  updatedAt?: Date | string | number
   tags?: string[]
   /** Path used to build the canonical URL; defaults to `path`. */
   canonicalPath?: string
   /** Post a Bluesky announcement (for comment threading) on first publish. */
   announce?: boolean
+}
+
+/** Coerce a Date | string | number into a valid Date, or undefined. */
+const toDate = (value?: Date | string | number): Date | undefined => {
+  if (value === undefined || value === null || value === '') return undefined
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
 }
 
 /**
@@ -157,12 +166,14 @@ async function publishDocument(
 
   const publisher = await getPublisher()
 
+  const publishedAt = toDate(input.publishedAt) ?? new Date()
+  const updatedAt = toDate(input.updatedAt)
+
   // Reuse an existing announcement post; otherwise create one for recent posts.
   let bskyPostUri = existing?.bskyPostUri ?? null
   let bskyPostCid = existing?.bskyPostCid ?? null
   const recentEnoughToAnnounce =
-    dateFns.differenceInDays(new Date(), input.publishedAt) <=
-    ANNOUNCE_MAX_AGE_DAYS
+    dateFns.differenceInDays(new Date(), publishedAt) <= ANNOUNCE_MAX_AGE_DAYS
 
   if (input.announce && !bskyPostUri && recentEnoughToAnnounce) {
     const url = config.url + canonicalPath
@@ -174,10 +185,10 @@ async function publishDocument(
   const docInput = {
     site: config.url,
     title: input.title,
-    publishedAt: input.publishedAt.toISOString(),
+    publishedAt: publishedAt.toISOString(),
     path: canonicalPath,
     description: input.description,
-    updatedAt: input.updatedAt?.toISOString(),
+    updatedAt: updatedAt?.toISOString(),
     tags: input.tags,
     textContent,
     content: {


### PR DESCRIPTION
## Problem

The prod build after merging #351 logged, for every blog post:

```
[standard-site] failed to publish blog "adhd": TypeError: input.updatedAt?.toISOString is not a function
    at publishDocument
```

`src/pages/blog/[...slug].astro` passes `remarkPluginFrontmatter.modified` as `updatedAt`. That field is typed as `Date` but the git-last-modified remark plugin actually emits a **string** at runtime, so `updatedAt.toISOString()` throws. The error is caught (publishing is best-effort/non-fatal), so the build stayed green — but no blog posts published. Link posts and feelings were unaffected since they don't pass `updatedAt`.

## Fix

- Add a `toDate(Date | string | number)` helper that returns a valid `Date` or `undefined`.
- Coerce both `publishedAt` and `updatedAt` through it before `.toISOString()` / `differenceInDays`.
- Widen `PublishInput.publishedAt` / `updatedAt` to `Date | string | number` to match reality.

## Verification

- `toDate` unit-checked against `Date`, ISO string, epoch ms, `undefined`, `""`, and garbage → correct in every case.
- `pnpm astro-check` and `pnpm lint` pass.

A real publish wasn't run to respect the "wait for deploy" boundary for blog content — the next production build will publish blog posts (deduped via content hash).

https://claude.ai/code/session_011VLNfg5PsxJYwMZVTjkcUn

---
_Generated by [Claude Code](https://claude.ai/code/session_011VLNfg5PsxJYwMZVTjkcUn)_