### PR TITLE
Add Astoria Park HTML Day 2026 freewrite page

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/pages/astoria-html-day-2026.html

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>✳️ HTML Day 2026 — Astoria Park Freewrite (Flyer)</title>
+    <title>HTML Day 2026 — Astoria Park Freewrite</title>
     <meta
       name="description"
       content="A community freewrite for HTML Day 2026 — Saturday, August 8th, 2-5pm at the South Hill of Astoria Park, under the Hell Gate Bridge. Bring a blanket and a laptop, write some HTML and poetry by hand. Free, all welcome. Text Eli to RSVP."
@@ -41,7 +41,7 @@
       }
 
       body {
-        max-width: 44rem;
+        max-width: 50rem;
         margin: 0 auto;
         padding: 2.5rem 1.25rem 3rem;
         font-family:
@@ -303,12 +303,13 @@
         .masthead {
           margin-top: 0;
           padding-top: 0;
-          padding-bottom: 0.4rem;
+          padding-bottom: 1rem;
           margin-bottom: 0.55rem;
         }
 
         .kicker {
           font-size: 8pt;
+          margin-bottom: 0.55rem;
         }
 
         /* The headline and big numbers use vw-based clamps for the screen;
@@ -367,7 +368,7 @@
         .hell-gate pre {
           display: inline-block;
           text-align: left;
-          font-size: 5pt;
+          font-size: 11pt;
           line-height: 1.05;
         }
 
@@ -439,7 +440,7 @@
       .tearoffs {
         /* Hidden everywhere by default; only the print stylesheet turns these
            on (as a flex row). Keeps them off screen and out of the way. */
-        display: none;
+        /* display: none; */
         flex-wrap: nowrap;
         border-top: 2px dashed #000;
         margin-top: 0.3rem;
@@ -554,20 +555,18 @@
       <!-- Warm copy for the web (kept off the printed flyer). -->
       <div class="screen-only">
         <p>
-          Once a year, people all over the world gather IRL to celebrate
-          <a href="https://html.energy">HTML Day</a> — a day to sit down
+          Once a year, people all over the world  IRL to celebrate
+          <a href="https://html.energy">HTML Day</a> — a day to sit down outside
           together and write HTML by hand. We're hosting one of those gatherings
           here in the neighborhood: a community <em>freewrite</em> on the grassy
           South Hill of Astoria Park, in the green shade of the
-          <a href="https://en.wikipedia.org/wiki/Hell_Gate_Bridge"
-            >Hell Gate Bridge</a
-          >.
+          <a href="https://en.wikipedia.org/wiki/Hell_Gate_Bridge">Hell Gate Bridge</a>.
         </p>
 
         <p>
           Bring a laptop and write a little HTML by hand, the way the early web
           was made — no framework, no build step, no JavaScript required. A
-          poem, a homepage, a love letter to the river. A few of us will be
+          poem, a homepage, a love letter to the city. A few of us will be
           working on <strong>poetry</strong>, so feel free to do the same. Never
           written a tag in your life? Come anyway — we'll get you from blank
           file to live page before the sun gets low.
@@ -620,6 +619,7 @@
           </div>
           <p class="site">
             <a
+              class="print-only"
               itemprop="url"
               href="https://eligundry.com/astoria-html-day-2026.html"
               >eligundry.com/astoria-html-day-2026</a
@@ -649,7 +649,7 @@
 
       <footer class="screen-only">
         <span class="star" aria-hidden="true">✳️</span>
-        part of <a href="https://html.energy">HTML Day 2026</a>
+        part of <a href="https://2026.html.energy">HTML Day 2026</a>
         <span class="star" aria-hidden="true">✳️</span>
       </footer>
 
@@ -659,7 +659,7 @@
         aria-label="ASCII art of the Hell Gate Bridge over the East River"
       >
         <pre>
-                T H E   H E L L   G A T E   B R I D G E
+                H E L L   G A T E   B R I D G E
 
   .=====._____________________________________________________.=====.
   |#####|            /____________________________            |#####|
@@ -674,13 +674,8 @@
 ~~|#####|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|#####|~~
 
        ASTORIA PARK  ✳     ✳     ✳     ✳     ✳  ASTORIA PARK
-</pre
-        >
+</pre>
       </div>
-      <p class="caption screen-only">
-        Hell Gate Bridge — rendered in html.energy green, the way it glows over
-        the park at golden hour.
-      </p>
 
       <!-- Classic neighborhood tear-off strips: printed flyer only. -->
       <p class="tearoffs-label print-only">✂ — tear off my number — ✂</p>

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -358,9 +358,12 @@
           overflow: visible;
           margin-top: 0.6rem;
           padding: 0.3rem;
+          text-align: center;
         }
 
         .hell-gate pre {
+          display: inline-block;
+          text-align: left;
           font-size: 5pt;
           line-height: 1.05;
         }
@@ -399,16 +402,17 @@
       .tearoffs {
         display: flex;
         flex-wrap: nowrap;
-        justify-content: center;
         border-top: 2px dashed #000;
         margin-top: 0.3rem;
       }
 
       .tearoffs .tab {
+        /* Each strip stretches to share the full width evenly. */
+        flex: 1 1 0;
         writing-mode: vertical-rl;
         text-orientation: mixed;
         border-right: 1px dashed #888;
-        padding: 0.7rem 0.25rem;
+        padding: 0.7rem 0;
         font-size: 8pt;
         letter-spacing: 0.03em;
         white-space: nowrap;
@@ -421,6 +425,7 @@
 
       .tearoffs .tab .num {
         font-weight: bold;
+        color: var(--link);
       }
     </style>
   </head>
@@ -598,23 +603,21 @@
         aria-label="ASCII art of the Hell Gate Bridge over the East River"
       >
         <pre>
-                        T H E   H E L L   G A T E   B R I D G E
+                T H E   H E L L   G A T E   B R I D G E
 
-                          _.-=""""""""""""""""""""=-._
-                      _.-'                            '-._
-                   .-'                                    '-.
-                 .'                                          '.
-               .'                                              '.
-   ____      .'                                                  '.      ____
-  |####|   .'                                                      '.   |####|
-  |####|__.'________________________________________________________'.__|####|
-  |####||==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==||####|
-  |####||  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  ||####|
-  |####||  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  ||####|
-~~|####||~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~||####|~~
-~~~~~~~~~~~~~~~~~~~~~~~~~ E A S T   R I V E R ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ASTORIA PARK  ✳        ✳        ✳        ✳        ✳        ✳   ASTORIA PARK
+  .=====._____________________________________________________.=====.
+  |#####|            /____________________________            |#####|
+  |#####|        /___  |  |  |  |  |  |  |  |  |  \___        |#####|
+  |#####|     /__|  |  |  |  |  |  |  |  |  |  |  |  |\__     |#####|
+  |#####|  /__|  |  |  |  |  |  |  |  |  |  |  |  |  |  |\__  |#####|
+  |#####|__|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |\_|#####|
+  |#####|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |#####|
+==|#####|=====================================================|#####|==
+  |#####|"""""""""""""""""""""""""""""""""""""""""""""""""""""|#####|
+~~|#####|~~~~~~~~~~~~~~~~ E A S T   R I V E R ~~~~~~~~~~~~~~~~|#####|~~
+~~|#####|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|#####|~~
+
+       ASTORIA PARK  ✳     ✳     ✳     ✳     ✳  ASTORIA PARK
 </pre
         >
       </div>
@@ -626,6 +629,12 @@
       <!-- Classic neighborhood tear-off strips: printed flyer only. -->
       <p class="tearoffs-label print-only">✂ — tear off my number — ✂</p>
       <div class="tearoffs print-only" aria-hidden="true">
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
         <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
         <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
         <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -252,7 +252,7 @@
       /* ---- Print: a single-page PDF to post around the neighborhood ---- */
       @page {
         size: letter portrait;
-        margin: 0.45in;
+        margin: 0.4in;
       }
 
       @media print {
@@ -298,21 +298,48 @@
           text-shadow: none;
         }
 
-        h1 {
-          font-size: 30pt;
-          margin: 0.15rem 0 0.3rem;
+        .masthead {
+          padding-bottom: 0.4rem;
+          margin-bottom: 0.55rem;
         }
 
-        h2 {
-          margin: 0.9rem 0 0.35rem;
+        .kicker {
+          font-size: 8pt;
+        }
+
+        /* The headline and big numbers use vw-based clamps for the screen;
+           on paper those balloon, so pin them to fixed point sizes. */
+        h1 {
+          font-size: 26pt;
+          margin: 0.1rem 0 0.2rem;
+        }
+
+        .subtitle {
+          font-size: 11pt;
+        }
+
+        .print-only p {
+          margin: 0 0 0.45rem;
+        }
+
+        .print-only .lede {
+          font-size: 12pt;
         }
 
         .banner {
           background: #fff;
           color: #000;
           border: 2px solid #000;
-          margin: 0.9rem 0;
-          padding: 0.5rem;
+          margin: 0.6rem 0;
+          padding: 0.4rem;
+        }
+
+        .banner .when {
+          font-size: 15pt;
+        }
+
+        .banner .where {
+          font-size: 11pt;
         }
 
         .banner .where a {
@@ -327,16 +354,26 @@
           border: 2px solid #000;
           text-shadow: none;
           overflow: visible;
-          margin-top: 0.9rem;
-          padding: 0.4rem;
+          margin-top: 0.6rem;
+          padding: 0.3rem;
         }
 
         .hell-gate pre {
-          font-size: 6pt;
+          font-size: 5pt;
+          line-height: 1.05;
         }
 
         .rsvp {
-          margin-top: 0.9rem;
+          margin-top: 0.6rem;
+          padding: 0.55rem;
+        }
+
+        .rsvp .number {
+          font-size: 18pt;
+        }
+
+        .tearoffs-label {
+          margin-top: 0.7rem;
         }
 
         .tearoffs,
@@ -497,18 +534,21 @@
         </p>
       </div>
 
-      <!-- Tight, CTA-focused copy for the printed flyer. -->
-      <p class="print-only">
-        Once a year, people everywhere gather to celebrate HTML Day — a day to
-        sit down together and write HTML by hand. We're hosting a community
-        <strong>freewrite</strong> on the South Hill of Astoria Park, under the
-        Hell Gate Bridge. Bring a blanket and a laptop and make something for
-        the web — a page, a poem, a love letter to the river. No experience
-        needed; we'll get you from blank file to live page. Come build something
-        with the neighborhood.
-      </p>
+      <!-- Fresh, flyer-only copy — written just for print, not reused from the web page. -->
+      <div class="print-only">
+        <p class="lede">
+          Hand-write a web page in the park. <strong>HTML Day</strong> is the
+          one Saturday a year when people everywhere make something small and
+          strange for the web — by hand, on purpose.
+        </p>
+        <p>
+          Bring a laptop, a blanket, and a full battery (there are no outlets
+          out here). New to code? I'll show you the ropes. Kids welcome and
+          poetry encouraged — or just come watch the bridge and say hello.
+        </p>
+      </div>
 
-      <section>
+      <section class="screen-only">
         <h2>Good to know</h2>
         <ul class="notes">
           <li><strong>Bring a blanket</strong> — we'll be on the grass.</li>
@@ -544,7 +584,7 @@
 
       <link itemprop="about" href="https://html.energy" />
 
-      <footer>
+      <footer class="screen-only">
         <span class="star" aria-hidden="true">✳️</span>
         part of <a href="https://html.energy">HTML Day 2026</a>
         <span class="star" aria-hidden="true">✳️</span>

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -6,7 +6,7 @@
     <title>✳️ HTML Day 2026 — Astoria Park Freewrite (Flyer)</title>
     <meta
       name="description"
-      content="A flyer for an html.energy freewrite on HTML Day 2026 — Saturday, August 8th, 2-5pm at the South Hill of Astoria Park, under the Hell Gate Bridge. Bring a blanket and a laptop, write some HTML and poetry by hand. Free, all welcome. Text Eli to RSVP."
+      content="A community freewrite for HTML Day 2026 — Saturday, August 8th, 2-5pm at the South Hill of Astoria Park, under the Hell Gate Bridge. Bring a blanket and a laptop, write some HTML and poetry by hand. Free, all welcome. Text Eli to RSVP."
     />
     <meta name="author" content="Eli Gundry" />
     <meta property="og:type" content="website" />
@@ -16,63 +16,12 @@
     />
     <meta
       property="og:description"
-      content="An html.energy freewrite under the Hell Gate Bridge. Sat Aug 8, 2026, 2-5pm, South Hill of Astoria Park. Bring a blanket and a laptop. Free, all welcome."
+      content="A community freewrite under the Hell Gate Bridge. Sat Aug 8, 2026, 2-5pm, South Hill of Astoria Park. Bring a blanket and a laptop. Free, all welcome."
     />
     <link
       rel="icon"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✳️</text></svg>"
     />
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "Event",
-        "name": "HTML Day 2026 — Astoria Park Freewrite",
-        "description": "An html.energy freewrite for HTML Day 2026, hosted by Eli Gundry on the South Hill of Astoria Park beneath the Hell Gate Bridge. Gather IRL to write and learn HTML by hand — no JavaScript required. Bring a blanket and a laptop; poetry encouraged. Free and open to everyone.",
-        "image": "https://eligundry.com/astoria-html-day-2026.html",
-        "startDate": "2026-08-08T14:00:00-04:00",
-        "endDate": "2026-08-08T17:00:00-04:00",
-        "eventStatus": "https://schema.org/EventScheduled",
-        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-        "location": {
-          "@type": "Place",
-          "name": "Astoria Park — South Hill",
-          "address": {
-            "@type": "PostalAddress",
-            "streetAddress": "Astoria Park, South Hill",
-            "addressLocality": "Astoria",
-            "addressRegion": "NY",
-            "postalCode": "11102",
-            "addressCountry": "US"
-          },
-          "geo": {
-            "@type": "GeoCoordinates",
-            "latitude": 40.7803863,
-            "longitude": -73.9211527
-          }
-        },
-        "organizer": {
-          "@type": "Person",
-          "name": "Eli Gundry",
-          "url": "https://eligundry.com",
-          "telephone": "+1-347-523-2652"
-        },
-        "about": {
-          "@type": "Thing",
-          "name": "HTML Day",
-          "url": "https://html.energy"
-        },
-        "isAccessibleForFree": true,
-        "offers": {
-          "@type": "Offer",
-          "name": "Free admission",
-          "price": "0",
-          "priceCurrency": "USD",
-          "availability": "https://schema.org/InStock",
-          "url": "https://eligundry.com/astoria-html-day-2026.html",
-          "validFrom": "2026-06-21T00:00:00-04:00"
-        }
-      }
-    </script>
     <style>
       :root {
         --energy-green: #39ff14;
@@ -101,6 +50,11 @@
         line-height: 1.55;
         color: var(--ink);
         background-color: var(--paper);
+      }
+
+      /* Anything meant only for the printed flyer is hidden on screen. */
+      .print-only {
+        display: none;
       }
 
       .flyer {
@@ -220,6 +174,7 @@
         border-radius: 6px;
         padding: 1rem;
         margin: 1.75rem 0 0;
+        font-style: normal;
       }
 
       .rsvp .label {
@@ -239,6 +194,11 @@
       .rsvp .number a {
         color: var(--ink);
         text-decoration: none;
+      }
+
+      .rsvp .site {
+        font-size: 0.95rem;
+        margin: 0.4rem 0 0;
       }
 
       footer {
@@ -274,44 +234,6 @@
         margin: 0.75rem 0 0;
       }
 
-      /* ---- Tear-off phone strips (classic neighborhood flyer) ---- */
-      .tearoffs-label {
-        text-align: center;
-        text-transform: uppercase;
-        letter-spacing: 0.16em;
-        font-size: 0.75rem;
-        margin: 1.75rem 0 0;
-        color: #555;
-      }
-
-      .tearoffs {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        border-top: 2px dashed var(--ink);
-        margin-top: 0.4rem;
-      }
-
-      .tearoffs .tab {
-        writing-mode: vertical-rl;
-        text-orientation: mixed;
-        border-right: 1px dashed #aaa;
-        padding: 0.85rem 0.3rem;
-        font-size: 0.8rem;
-        letter-spacing: 0.03em;
-        white-space: nowrap;
-        text-align: center;
-      }
-
-      .tearoffs .tab:first-child {
-        border-left: 1px dashed #aaa;
-      }
-
-      .tearoffs .tab .num {
-        color: var(--link);
-        font-weight: bold;
-      }
-
       /* ---- Mobile ---- */
       @media (max-width: 480px) {
         body {
@@ -327,10 +249,10 @@
         }
       }
 
-      /* ---- Print: optimized for a single-page PDF to post around town ---- */
+      /* ---- Print: a single-page PDF to post around the neighborhood ---- */
       @page {
         size: letter portrait;
-        margin: 0.5in;
+        margin: 0.45in;
       }
 
       @media print {
@@ -338,16 +260,25 @@
           max-width: none;
           margin: 0;
           padding: 0;
-          font-size: 11pt;
-          line-height: 1.4;
+          font-size: 10.5pt;
+          line-height: 1.35;
           color: #000;
           background: #fff;
+        }
+
+        /* Swap screen copy for the tighter, CTA-focused flyer copy. */
+        .screen-only {
+          display: none !important;
+        }
+
+        .print-only {
+          display: revert;
         }
 
         .flyer {
           border: 2px solid #000;
           border-radius: 0;
-          padding: 0.4in 0.45in;
+          padding: 0.3in 0.4in;
         }
 
         a {
@@ -367,10 +298,21 @@
           text-shadow: none;
         }
 
+        h1 {
+          font-size: 30pt;
+          margin: 0.15rem 0 0.3rem;
+        }
+
+        h2 {
+          margin: 0.9rem 0 0.35rem;
+        }
+
         .banner {
           background: #fff;
           color: #000;
           border: 2px solid #000;
+          margin: 0.9rem 0;
+          padding: 0.5rem;
         }
 
         .banner .where a {
@@ -385,28 +327,98 @@
           border: 2px solid #000;
           text-shadow: none;
           overflow: visible;
+          margin-top: 0.9rem;
+          padding: 0.4rem;
         }
 
         .hell-gate pre {
-          font-size: 6.5pt;
+          font-size: 6pt;
+        }
+
+        .rsvp {
+          margin-top: 0.9rem;
         }
 
         .tearoffs,
         .rsvp,
-        .banner {
+        .banner,
+        .hell-gate {
           page-break-inside: avoid;
         }
+      }
+
+      /* ---- Tear-off phone strips: only for the printed flyer ---- */
+      .tearoffs-label {
+        text-align: center;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: 0.75rem;
+        margin: 1rem 0 0;
+        color: #000;
+      }
+
+      .tearoffs {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: center;
+        border-top: 2px dashed #000;
+        margin-top: 0.3rem;
+      }
+
+      .tearoffs .tab {
+        writing-mode: vertical-rl;
+        text-orientation: mixed;
+        border-right: 1px dashed #888;
+        padding: 0.7rem 0.25rem;
+        font-size: 8pt;
+        letter-spacing: 0.03em;
+        white-space: nowrap;
+        text-align: center;
+      }
+
+      .tearoffs .tab:first-child {
+        border-left: 1px dashed #888;
+      }
+
+      .tearoffs .tab .num {
+        font-weight: bold;
       }
     </style>
   </head>
   <body>
-    <article class="flyer">
+    <article class="flyer" itemscope itemtype="https://schema.org/Event">
+      <!-- Schema.org Event, expressed as microdata in the markup itself. -->
+      <meta
+        itemprop="description"
+        content="A community freewrite for HTML Day 2026 on the South Hill of Astoria Park, beneath the Hell Gate Bridge. Gather IRL to write and learn HTML by hand — no JavaScript required. Bring a blanket and a laptop; poetry encouraged. Free and open to everyone."
+      />
+      <meta
+        itemprop="image"
+        content="https://eligundry.com/astoria-html-day-2026.html"
+      />
+      <meta
+        itemprop="eventStatus"
+        content="https://schema.org/EventScheduled"
+      />
+      <meta
+        itemprop="eventAttendanceMode"
+        content="https://schema.org/OfflineEventAttendanceMode"
+      />
+      <meta itemprop="isAccessibleForFree" content="true" />
+      <meta itemprop="endDate" content="2026-08-08T17:00:00-04:00" />
+      <link
+        itemprop="url"
+        href="https://eligundry.com/astoria-html-day-2026.html"
+      />
+
       <header class="masthead">
-        <p class="kicker">You're Invited · It's Free</p>
+        <p class="kicker">A Community Freewrite · Free · All Welcome</p>
         <h1>
-          <span class="star">✳️</span>
-          <a href="https://html.energy">HTML Day 2026</a>
-          <span class="star">✳️</span>
+          <span class="star" aria-hidden="true">✳️</span>
+          <span itemprop="name"
+            ><a href="https://html.energy">HTML Day 2026</a></span
+          >
+          <span class="star" aria-hidden="true">✳️</span>
         </h1>
         <p class="subtitle">
           a freewrite in Astoria Park, under the Hell Gate Bridge
@@ -414,59 +426,125 @@
       </header>
 
       <div class="banner">
-        <span class="when">Saturday, August 8th · 2–5 PM</span>
-        <span class="where">
-          South Hill, <strong>Astoria Park</strong> ·
-          <a
-            href="https://www.google.com/maps/search/?api=1&amp;query=40.7803863,-73.9211527"
-            >map ↗</a
+        <span class="when">
+          <time itemprop="startDate" datetime="2026-08-08T14:00:00-04:00"
+            >Saturday, August 8th · 2–5 PM</time
           >
+        </span>
+        <span
+          class="where"
+          itemprop="location"
+          itemscope
+          itemtype="https://schema.org/Place"
+        >
+          <span itemprop="name">South Hill, <strong>Astoria Park</strong></span>
+          <span
+            itemprop="address"
+            itemscope
+            itemtype="https://schema.org/PostalAddress"
+          >
+            <meta itemprop="streetAddress" content="Astoria Park, South Hill" />
+            <meta itemprop="addressLocality" content="Astoria" />
+            <meta itemprop="addressRegion" content="NY" />
+            <meta itemprop="postalCode" content="11102" />
+            <meta itemprop="addressCountry" content="US" />
+          </span>
+          <span
+            itemprop="geo"
+            itemscope
+            itemtype="https://schema.org/GeoCoordinates"
+          >
+            <meta itemprop="latitude" content="40.7803863" />
+            <meta itemprop="longitude" content="-73.9211527" />
+          </span>
+          <span class="screen-only">
+            ·
+            <a
+              itemprop="hasMap"
+              href="https://www.google.com/maps/search/?api=1&amp;query=40.7803863,-73.9211527"
+              >map ↗</a
+            >
+          </span>
         </span>
       </div>
 
-      <p>
-        Once a year, people all over the world gather IRL to celebrate
-        <a href="https://html.energy">HTML Day</a> — a day to sit down together
-        and write HTML by hand. I'm hosting one of those gatherings, a
-        <em>freewrite</em>, on the grassy South Hill of Astoria Park, in the
-        green shade of the
-        <a href="https://en.wikipedia.org/wiki/Hell_Gate_Bridge"
-          >Hell Gate Bridge</a
-        >.
-      </p>
+      <!-- Warm copy for the web (kept off the printed flyer). -->
+      <div class="screen-only">
+        <p>
+          Once a year, people all over the world gather IRL to celebrate
+          <a href="https://html.energy">HTML Day</a> — a day to sit down
+          together and write HTML by hand. We're hosting one of those gatherings
+          here in the neighborhood: a community <em>freewrite</em> on the grassy
+          South Hill of Astoria Park, in the green shade of the
+          <a href="https://en.wikipedia.org/wiki/Hell_Gate_Bridge"
+            >Hell Gate Bridge</a
+          >.
+        </p>
 
-      <p>
-        Bring a laptop and write a little HTML the way our forefathers &amp;
-        foremothers once did — no framework, no build step, no JavaScript
-        required. A poem, a homepage, a love letter to the river. I'll be
-        working on some <strong>poetry</strong>, so feel free to do the same.
-        Never written a tag in your life? Come anyway — I'll get you from blank
-        file to live page before the sun gets low.
-      </p>
+        <p>
+          Bring a laptop and write a little HTML by hand, the way the early web
+          was made — no framework, no build step, no JavaScript required. A
+          poem, a homepage, a love letter to the river. A few of us will be
+          working on <strong>poetry</strong>, so feel free to do the same. Never
+          written a tag in your life? Come anyway — we'll get you from blank
+          file to live page before the sun gets low.
+        </p>
 
-      <h2>Good to know</h2>
-      <ul class="notes">
-        <li><strong>Bring a blanket</strong> — we'll be on the grass.</li>
-        <li>I'm bringing a sandwich; pack a snack or a picnic of your own.</li>
-        <li>
-          My kid will be hanging with us for part of the afternoon, so it's a
-          kid-friendly crowd.
-        </li>
-        <li>Poetry welcome and encouraged — HTML optional but lovely.</li>
-        <li>Charge your battery; there are no outlets in the park.</li>
-      </ul>
-
-      <div class="rsvp">
-        <p class="label">RSVP / questions — text Eli</p>
-        <div class="number">
-          <a href="tel:+13475232652">347.523.2652</a>
-        </div>
+        <p>
+          However you find your way to the web, this is about making something
+          together and getting to know the people who build alongside you. Pull
+          up a patch of grass and join us.
+        </p>
       </div>
 
+      <!-- Tight, CTA-focused copy for the printed flyer. -->
+      <p class="print-only">
+        Once a year, people everywhere gather to celebrate HTML Day — a day to
+        sit down together and write HTML by hand. We're hosting a community
+        <strong>freewrite</strong> on the South Hill of Astoria Park, under the
+        Hell Gate Bridge. Bring a blanket and a laptop and make something for
+        the web — a page, a poem, a love letter to the river. No experience
+        needed; we'll get you from blank file to live page. Come build something
+        with the neighborhood.
+      </p>
+
+      <section>
+        <h2>Good to know</h2>
+        <ul class="notes">
+          <li><strong>Bring a blanket</strong> — we'll be on the grass.</li>
+          <li>Pack a snack or a picnic; there'll be sandwiches to share.</li>
+          <li>It's a kid-friendly crowd — little ones welcome.</li>
+          <li>Poetry welcome and encouraged — HTML optional but lovely.</li>
+          <li>Charge your battery; there are no outlets in the park.</li>
+        </ul>
+      </section>
+
+      <address
+        class="rsvp"
+        itemprop="organizer"
+        itemscope
+        itemtype="https://schema.org/Person"
+      >
+        <p class="label">RSVP / questions — text Eli</p>
+        <div class="number">
+          <a itemprop="telephone" href="tel:+13475232652">347.523.2652</a>
+        </div>
+        <p class="site">
+          <a
+            itemprop="url"
+            href="https://eligundry.com/astoria-html-day-2026.html"
+            >eligundry.com/astoria-html-day-2026</a
+          >
+        </p>
+        <meta itemprop="name" content="Eli Gundry" />
+      </address>
+
+      <link itemprop="about" href="https://html.energy" />
+
       <footer>
-        <span class="star">✳️</span>
-        hosted by <a href="https://eligundry.com">Eli Gundry</a>
-        <span class="star">✳️</span>
+        <span class="star" aria-hidden="true">✳️</span>
+        part of <a href="https://html.energy">HTML Day 2026</a>
+        <span class="star" aria-hidden="true">✳️</span>
       </footer>
 
       <div
@@ -495,13 +573,14 @@
 </pre
         >
       </div>
-      <p class="caption">
+      <p class="caption screen-only">
         Hell Gate Bridge — rendered in html.energy green, the way it glows over
         the park at golden hour.
       </p>
 
-      <p class="tearoffs-label">✂ — tear off my number — ✂</p>
-      <div class="tearoffs" aria-hidden="true">
+      <!-- Classic neighborhood tear-off strips: printed flyer only. -->
+      <p class="tearoffs-label print-only">✂ — tear off my number — ✂</p>
+      <div class="tearoffs print-only" aria-hidden="true">
         <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
         <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
         <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>✳️ HTML Day 2026 — Astoria Park Freewrite</title>
+    <meta
+      name="description"
+      content="Join Eli Gundry for an html.energy freewrite on HTML Day 2026 — Saturday, August 8th, 2-5pm in Astoria Park, under the Hell Gate Bridge. Bring a laptop, write some HTML by hand. Free, all welcome."
+    />
+    <meta name="author" content="Eli Gundry" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="HTML Day 2026 — Astoria Park Freewrite"
+    />
+    <meta
+      property="og:description"
+      content="An html.energy freewrite under the Hell Gate Bridge. Sat Aug 8, 2026, 2-5pm. Bring a laptop, write some HTML by hand. Free, all welcome."
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✳️</text></svg>"
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        "name": "HTML Day 2026 — Astoria Park Freewrite",
+        "description": "An html.energy freewrite for HTML Day 2026, hosted by Eli Gundry in Astoria Park beneath the Hell Gate Bridge. Gather IRL to write and learn HTML by hand — no JavaScript required. Bring a laptop and an idea. Free and open to everyone.",
+        "image": "https://eligundry.com/astoria-html-day-2026.html",
+        "startDate": "2026-08-08T14:00:00-04:00",
+        "endDate": "2026-08-08T17:00:00-04:00",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+        "location": {
+          "@type": "Place",
+          "name": "Astoria Park",
+          "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "Shore Boulevard",
+            "addressLocality": "Astoria",
+            "addressRegion": "NY",
+            "postalCode": "11102",
+            "addressCountry": "US"
+          },
+          "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": 40.7795,
+            "longitude": -73.9229
+          }
+        },
+        "organizer": {
+          "@type": "Person",
+          "name": "Eli Gundry",
+          "url": "https://eligundry.com"
+        },
+        "about": {
+          "@type": "Thing",
+          "name": "HTML Day",
+          "url": "https://html.energy"
+        },
+        "isAccessibleForFree": true,
+        "offers": {
+          "@type": "Offer",
+          "name": "Free admission",
+          "price": "0",
+          "priceCurrency": "USD",
+          "availability": "https://schema.org/InStock",
+          "url": "https://eligundry.com/astoria-html-day-2026.html",
+          "validFrom": "2026-06-21T00:00:00-04:00"
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --energy-green: #39ff14;
+        --ink: #16170f;
+        --paper: #fbfbf3;
+      }
+
+      html {
+        box-sizing: border-box;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: inherit;
+      }
+
+      body {
+        max-width: 46rem;
+        margin: 0 auto;
+        padding: 2.5rem 1.25rem 4rem;
+        font-family:
+          ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+        font-size: 1.2rem;
+        line-height: 1.6;
+        color: var(--ink);
+        background-color: var(--paper);
+      }
+
+      h1 {
+        font-size: 2rem;
+        line-height: 1.2;
+        margin-bottom: 0.25rem;
+      }
+
+      h2 {
+        font-size: 1.35rem;
+        margin-top: 2.5rem;
+      }
+
+      a {
+        color: #0a7d2c;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 2px;
+      }
+
+      a:hover,
+      a:focus {
+        background-color: var(--energy-green);
+        color: var(--ink);
+        text-decoration: none;
+      }
+
+      .star {
+        color: var(--energy-green);
+        text-shadow:
+          0 0 4px var(--energy-green),
+          0 0 12px var(--energy-green);
+      }
+
+      .tagline {
+        font-style: italic;
+        color: #555;
+        margin-top: 0;
+      }
+
+      .details {
+        border: 2px solid var(--ink);
+        border-radius: 6px;
+        padding: 1rem 1.5rem;
+        margin: 2rem 0;
+        background: #fff;
+      }
+
+      .details dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        gap: 0.4rem 1rem;
+      }
+
+      .details dt {
+        font-weight: bold;
+        text-transform: uppercase;
+        font-size: 0.8rem;
+        letter-spacing: 0.06em;
+        align-self: center;
+      }
+
+      .details dd {
+        margin: 0;
+      }
+
+      footer {
+        margin-top: 2.5rem;
+        font-weight: bold;
+      }
+
+      /* The Hell Gate Bridge, glowing in html.energy green on black. */
+      .hell-gate {
+        margin-top: 3rem;
+        background: #000;
+        color: var(--energy-green);
+        padding: 1.25rem 1rem;
+        border-radius: 6px;
+        overflow-x: auto;
+        font-size: clamp(0.42rem, 1.9vw, 0.8rem);
+        line-height: 1.15;
+        text-shadow: 0 0 6px rgba(57, 255, 20, 0.6);
+      }
+
+      .hell-gate pre {
+        margin: 0;
+      }
+
+      .caption {
+        text-align: center;
+        font-size: 0.85rem;
+        color: #555;
+        font-style: italic;
+        margin-top: 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>
+        <span class="star">✳️</span>
+        <a href="https://html.energy">HTML Day 2026</a> in Astoria Park
+        <span class="star">✳️</span>
+      </h1>
+      <p class="tagline">
+        a freewrite under the Hell Gate Bridge — write some html by hand, by the
+        water.
+      </p>
+
+      <p>
+        On <strong>Saturday, August 8th, 2026</strong>, people all over the
+        world will gather to celebrate
+        <a href="https://html.energy">HTML Day</a>: a day to meet up IRL and
+        write and learn HTML together. I'm hosting one of those gatherings — a
+        <em>freewrite</em> — in <strong>Astoria Park</strong>, in the green
+        shade of the
+        <a href="https://en.wikipedia.org/wiki/Hell_Gate_Bridge"
+          >Hell Gate Bridge</a
+        >, where Queens meets the East River.
+      </p>
+
+      <p>
+        A freewrite is exactly what it sounds like. Bring a laptop, bring an
+        idea, and write a little HTML the way our forefathers &amp; foremothers
+        once did — no framework, no build step, no JavaScript required.
+        Hand-code a poem, a homepage, a love letter, a list of birds you can see
+        from the park. Then push it to a server and, boom, you're on the web.
+        That's the whole
+        <a href="https://html.energy">web0</a> dream.
+      </p>
+
+      <p>
+        No experience needed. If you've never written a tag in your life, come
+        anyway — I'll get you from blank file to live page before the sun gets
+        too low over the river.
+      </p>
+
+      <section class="details" aria-label="Event details">
+        <h2 style="margin-top: 0">The details</h2>
+        <dl>
+          <dt>What</dt>
+          <dd>An html.energy freewrite for HTML Day 2026</dd>
+          <dt>When</dt>
+          <dd>Saturday, August 8th, 2026 · 2:00–5:00 PM</dd>
+          <dt>Where</dt>
+          <dd>Astoria Park, by the Hell Gate Bridge · Astoria, Queens, NY</dd>
+          <dt>Cost</dt>
+          <dd>Free — all are welcome</dd>
+          <dt>Bring</dt>
+          <dd>A laptop, a charged battery, and an idea</dd>
+          <dt>Host</dt>
+          <dd><a href="https://eligundry.com">Eli Gundry</a></dd>
+        </dl>
+      </section>
+
+      <p>
+        Come write some HTML with me. I had a ball making this very page by hand
+        — won't you join me and the
+        <a href="https://html.energy">web0</a> movement?
+      </p>
+
+      <footer>
+        <p>
+          <span class="star">✳️</span>
+          <a href="https://eligundry.com">Eli Gundry</a>
+          <span class="star">✳️</span>
+        </p>
+      </footer>
+
+      <div
+        class="hell-gate"
+        role="img"
+        aria-label="ASCII art of the Hell Gate Bridge over the East River"
+      >
+        <pre>
+                        T H E   H E L L   G A T E   B R I D G E
+
+                          _.-=""""""""""""""""""""=-._
+                      _.-'                            '-._
+                   .-'                                    '-.
+                 .'                                          '.
+               .'                                              '.
+   ____      .'                                                  '.      ____
+  |####|   .'                                                      '.   |####|
+  |####|__.'________________________________________________________'.__|####|
+  |####||==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==|==||####|
+  |####||  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  ||####|
+  |####||  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  ||####|
+~~|####||~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~|~~||####|~~
+~~~~~~~~~~~~~~~~~~~~~~~~~ E A S T   R I V E R ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ASTORIA PARK  ✳        ✳        ✳        ✳        ✳        ✳   ASTORIA PARK
+</pre
+        >
+      </div>
+      <p class="caption">
+        Hell Gate Bridge — rendered in html.energy green, the way it glows over
+        the park at golden hour.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -276,9 +276,9 @@
         }
 
         .flyer {
-          border: 2px solid #000;
+          border: none;
           border-radius: 0;
-          padding: 0.3in 0.4in;
+          padding: 0 0.4in;
         }
 
         a {
@@ -299,6 +299,8 @@
         }
 
         .masthead {
+          margin-top: 0;
+          padding-top: 0;
           padding-bottom: 0.4rem;
           margin-bottom: 0.55rem;
         }

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>✳️ HTML Day 2026 — Astoria Park Freewrite</title>
+    <title>✳️ HTML Day 2026 — Astoria Park Freewrite (Flyer)</title>
     <meta
       name="description"
-      content="Join Eli Gundry for an html.energy freewrite on HTML Day 2026 — Saturday, August 8th, 2-5pm in Astoria Park, under the Hell Gate Bridge. Bring a laptop, write some HTML by hand. Free, all welcome."
+      content="A flyer for an html.energy freewrite on HTML Day 2026 — Saturday, August 8th, 2-5pm at the South Hill of Astoria Park, under the Hell Gate Bridge. Bring a blanket and a laptop, write some HTML and poetry by hand. Free, all welcome. Text Eli to RSVP."
     />
     <meta name="author" content="Eli Gundry" />
     <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@
     />
     <meta
       property="og:description"
-      content="An html.energy freewrite under the Hell Gate Bridge. Sat Aug 8, 2026, 2-5pm. Bring a laptop, write some HTML by hand. Free, all welcome."
+      content="An html.energy freewrite under the Hell Gate Bridge. Sat Aug 8, 2026, 2-5pm, South Hill of Astoria Park. Bring a blanket and a laptop. Free, all welcome."
     />
     <link
       rel="icon"
@@ -27,7 +27,7 @@
         "@context": "https://schema.org",
         "@type": "Event",
         "name": "HTML Day 2026 — Astoria Park Freewrite",
-        "description": "An html.energy freewrite for HTML Day 2026, hosted by Eli Gundry in Astoria Park beneath the Hell Gate Bridge. Gather IRL to write and learn HTML by hand — no JavaScript required. Bring a laptop and an idea. Free and open to everyone.",
+        "description": "An html.energy freewrite for HTML Day 2026, hosted by Eli Gundry on the South Hill of Astoria Park beneath the Hell Gate Bridge. Gather IRL to write and learn HTML by hand — no JavaScript required. Bring a blanket and a laptop; poetry encouraged. Free and open to everyone.",
         "image": "https://eligundry.com/astoria-html-day-2026.html",
         "startDate": "2026-08-08T14:00:00-04:00",
         "endDate": "2026-08-08T17:00:00-04:00",
@@ -35,10 +35,10 @@
         "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
         "location": {
           "@type": "Place",
-          "name": "Astoria Park",
+          "name": "Astoria Park — South Hill",
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "Shore Boulevard",
+            "streetAddress": "Astoria Park, South Hill",
             "addressLocality": "Astoria",
             "addressRegion": "NY",
             "postalCode": "11102",
@@ -46,14 +46,15 @@
           },
           "geo": {
             "@type": "GeoCoordinates",
-            "latitude": 40.7795,
-            "longitude": -73.9229
+            "latitude": 40.7803863,
+            "longitude": -73.9211527
           }
         },
         "organizer": {
           "@type": "Person",
           "name": "Eli Gundry",
-          "url": "https://eligundry.com"
+          "url": "https://eligundry.com",
+          "telephone": "+1-347-523-2652"
         },
         "about": {
           "@type": "Thing",
@@ -76,6 +77,7 @@
       :root {
         --energy-green: #39ff14;
         --ink: #16170f;
+        --link: #0a7d2c;
         --paper: #fbfbf3;
       }
 
@@ -90,30 +92,107 @@
       }
 
       body {
-        max-width: 46rem;
+        max-width: 44rem;
         margin: 0 auto;
-        padding: 2.5rem 1.25rem 4rem;
+        padding: 2.5rem 1.25rem 3rem;
         font-family:
           ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
         font-size: 1.2rem;
-        line-height: 1.6;
+        line-height: 1.55;
         color: var(--ink);
         background-color: var(--paper);
       }
 
+      .flyer {
+        border: 3px solid var(--ink);
+        border-radius: 8px;
+        padding: 2rem 1.75rem;
+        background: #fff;
+      }
+
+      /* ---- Masthead ---- */
+      .masthead {
+        text-align: center;
+        border-bottom: 3px double var(--ink);
+        padding-bottom: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .kicker {
+        text-transform: uppercase;
+        letter-spacing: 0.22em;
+        font-size: 0.85rem;
+        font-weight: bold;
+        margin: 0;
+      }
+
       h1 {
-        font-size: 2rem;
-        line-height: 1.2;
-        margin-bottom: 0.25rem;
+        font-size: clamp(2.1rem, 7vw, 3.25rem);
+        line-height: 1;
+        margin: 0.4rem 0 0.5rem;
+        letter-spacing: -0.01em;
+      }
+
+      h1 a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .subtitle {
+        font-style: italic;
+        font-size: 1.15rem;
+        margin: 0;
+        color: #444;
+      }
+
+      .star {
+        color: var(--energy-green);
+        text-shadow:
+          0 0 4px var(--energy-green),
+          0 0 12px var(--energy-green);
+      }
+
+      /* ---- The big when/where banner ---- */
+      .banner {
+        text-align: center;
+        background: var(--ink);
+        color: var(--paper);
+        border-radius: 6px;
+        padding: 1rem 1rem 1.1rem;
+        margin: 1.5rem 0;
+      }
+
+      .banner .when {
+        font-size: clamp(1.4rem, 5vw, 2rem);
+        font-weight: bold;
+        line-height: 1.1;
+        display: block;
+      }
+
+      .banner .where {
+        display: block;
+        margin-top: 0.35rem;
+        font-size: 1.05rem;
+      }
+
+      .banner .where a {
+        color: var(--energy-green);
+      }
+
+      p {
+        margin: 0 0 1rem;
       }
 
       h2 {
-        font-size: 1.35rem;
-        margin-top: 2.5rem;
+        font-size: 1.3rem;
+        margin: 1.75rem 0 0.6rem;
+        border-bottom: 2px solid var(--ink);
+        display: inline-block;
+        padding-bottom: 0.1rem;
       }
 
       a {
-        color: #0a7d2c;
+        color: var(--link);
         text-decoration-thickness: 2px;
         text-underline-offset: 2px;
       }
@@ -125,66 +204,66 @@
         text-decoration: none;
       }
 
-      .star {
-        color: var(--energy-green);
-        text-shadow:
-          0 0 4px var(--energy-green),
-          0 0 12px var(--energy-green);
+      ul.notes {
+        margin: 0;
+        padding-left: 1.2rem;
       }
 
-      .tagline {
-        font-style: italic;
-        color: #555;
-        margin-top: 0;
+      ul.notes li {
+        margin-bottom: 0.5rem;
       }
 
-      .details {
-        border: 2px solid var(--ink);
+      /* ---- RSVP call-to-action ---- */
+      .rsvp {
+        text-align: center;
+        border: 2px dashed var(--ink);
         border-radius: 6px;
-        padding: 1rem 1.5rem;
-        margin: 2rem 0;
-        background: #fff;
+        padding: 1rem;
+        margin: 1.75rem 0 0;
       }
 
-      .details dl {
-        margin: 0;
-        display: grid;
-        grid-template-columns: max-content 1fr;
-        gap: 0.4rem 1rem;
-      }
-
-      .details dt {
-        font-weight: bold;
+      .rsvp .label {
         text-transform: uppercase;
+        letter-spacing: 0.16em;
         font-size: 0.8rem;
-        letter-spacing: 0.06em;
-        align-self: center;
+        font-weight: bold;
+        margin: 0 0 0.25rem;
       }
 
-      .details dd {
-        margin: 0;
+      .rsvp .number {
+        font-size: clamp(1.5rem, 6vw, 2.25rem);
+        font-weight: bold;
+        white-space: nowrap;
+      }
+
+      .rsvp .number a {
+        color: var(--ink);
+        text-decoration: none;
       }
 
       footer {
-        margin-top: 2.5rem;
+        text-align: center;
+        margin-top: 1.5rem;
         font-weight: bold;
       }
 
-      /* The Hell Gate Bridge, glowing in html.energy green on black. */
+      /* ---- The Hell Gate Bridge, glowing in html.energy green ---- */
       .hell-gate {
-        margin-top: 3rem;
+        margin-top: 1.75rem;
         background: #000;
         color: var(--energy-green);
-        padding: 1.25rem 1rem;
+        padding: 1.1rem 0.75rem;
         border-radius: 6px;
         overflow-x: auto;
-        font-size: clamp(0.42rem, 1.9vw, 0.8rem);
-        line-height: 1.15;
         text-shadow: 0 0 6px rgba(57, 255, 20, 0.6);
       }
 
       .hell-gate pre {
         margin: 0;
+        /* Sized so the full 78-column drawing fits the screen width down to
+           narrow phones, while capping out at a comfortable size on desktop. */
+        font-size: clamp(0.34rem, 1.85vw, 0.95rem);
+        line-height: 1.15;
       }
 
       .caption {
@@ -192,80 +271,202 @@
         font-size: 0.85rem;
         color: #555;
         font-style: italic;
-        margin-top: 0.75rem;
+        margin: 0.75rem 0 0;
+      }
+
+      /* ---- Tear-off phone strips (classic neighborhood flyer) ---- */
+      .tearoffs-label {
+        text-align: center;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: 0.75rem;
+        margin: 1.75rem 0 0;
+        color: #555;
+      }
+
+      .tearoffs {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        border-top: 2px dashed var(--ink);
+        margin-top: 0.4rem;
+      }
+
+      .tearoffs .tab {
+        writing-mode: vertical-rl;
+        text-orientation: mixed;
+        border-right: 1px dashed #aaa;
+        padding: 0.85rem 0.3rem;
+        font-size: 0.8rem;
+        letter-spacing: 0.03em;
+        white-space: nowrap;
+        text-align: center;
+      }
+
+      .tearoffs .tab:first-child {
+        border-left: 1px dashed #aaa;
+      }
+
+      .tearoffs .tab .num {
+        color: var(--link);
+        font-weight: bold;
+      }
+
+      /* ---- Mobile ---- */
+      @media (max-width: 480px) {
+        body {
+          padding: 1.25rem 0.75rem 2.5rem;
+        }
+
+        .flyer {
+          padding: 1.25rem 1rem;
+        }
+
+        .hell-gate {
+          padding: 0.85rem 0.4rem;
+        }
+      }
+
+      /* ---- Print: optimized for a single-page PDF to post around town ---- */
+      @page {
+        size: letter portrait;
+        margin: 0.5in;
+      }
+
+      @media print {
+        body {
+          max-width: none;
+          margin: 0;
+          padding: 0;
+          font-size: 11pt;
+          line-height: 1.4;
+          color: #000;
+          background: #fff;
+        }
+
+        .flyer {
+          border: 2px solid #000;
+          border-radius: 0;
+          padding: 0.4in 0.45in;
+        }
+
+        a {
+          color: #000;
+          text-decoration: none;
+        }
+
+        a:hover,
+        a:focus {
+          background: transparent;
+          color: #000;
+        }
+
+        /* Stars and headings print as solid black ink — no glow, no toner-hungry fills. */
+        .star {
+          color: #000;
+          text-shadow: none;
+        }
+
+        .banner {
+          background: #fff;
+          color: #000;
+          border: 2px solid #000;
+        }
+
+        .banner .where a {
+          color: #000;
+        }
+
+        /* The bridge prints as black ink on white so it stays crisp on a
+           photocopier and doesn't drink a cartridge of toner. */
+        .hell-gate {
+          background: #fff;
+          color: #000;
+          border: 2px solid #000;
+          text-shadow: none;
+          overflow: visible;
+        }
+
+        .hell-gate pre {
+          font-size: 6.5pt;
+        }
+
+        .tearoffs,
+        .rsvp,
+        .banner {
+          page-break-inside: avoid;
+        }
       }
     </style>
   </head>
   <body>
-    <main>
-      <h1>
-        <span class="star">✳️</span>
-        <a href="https://html.energy">HTML Day 2026</a> in Astoria Park
-        <span class="star">✳️</span>
-      </h1>
-      <p class="tagline">
-        a freewrite under the Hell Gate Bridge — write some html by hand, by the
-        water.
-      </p>
+    <article class="flyer">
+      <header class="masthead">
+        <p class="kicker">You're Invited · It's Free</p>
+        <h1>
+          <span class="star">✳️</span>
+          <a href="https://html.energy">HTML Day 2026</a>
+          <span class="star">✳️</span>
+        </h1>
+        <p class="subtitle">
+          a freewrite in Astoria Park, under the Hell Gate Bridge
+        </p>
+      </header>
+
+      <div class="banner">
+        <span class="when">Saturday, August 8th · 2–5 PM</span>
+        <span class="where">
+          South Hill, <strong>Astoria Park</strong> ·
+          <a
+            href="https://www.google.com/maps/search/?api=1&amp;query=40.7803863,-73.9211527"
+            >map ↗</a
+          >
+        </span>
+      </div>
 
       <p>
-        On <strong>Saturday, August 8th, 2026</strong>, people all over the
-        world will gather to celebrate
-        <a href="https://html.energy">HTML Day</a>: a day to meet up IRL and
-        write and learn HTML together. I'm hosting one of those gatherings — a
-        <em>freewrite</em> — in <strong>Astoria Park</strong>, in the green
-        shade of the
+        Once a year, people all over the world gather IRL to celebrate
+        <a href="https://html.energy">HTML Day</a> — a day to sit down together
+        and write HTML by hand. I'm hosting one of those gatherings, a
+        <em>freewrite</em>, on the grassy South Hill of Astoria Park, in the
+        green shade of the
         <a href="https://en.wikipedia.org/wiki/Hell_Gate_Bridge"
           >Hell Gate Bridge</a
-        >, where Queens meets the East River.
+        >.
       </p>
 
       <p>
-        A freewrite is exactly what it sounds like. Bring a laptop, bring an
-        idea, and write a little HTML the way our forefathers &amp; foremothers
-        once did — no framework, no build step, no JavaScript required.
-        Hand-code a poem, a homepage, a love letter, a list of birds you can see
-        from the park. Then push it to a server and, boom, you're on the web.
-        That's the whole
-        <a href="https://html.energy">web0</a> dream.
+        Bring a laptop and write a little HTML the way our forefathers &amp;
+        foremothers once did — no framework, no build step, no JavaScript
+        required. A poem, a homepage, a love letter to the river. I'll be
+        working on some <strong>poetry</strong>, so feel free to do the same.
+        Never written a tag in your life? Come anyway — I'll get you from blank
+        file to live page before the sun gets low.
       </p>
 
-      <p>
-        No experience needed. If you've never written a tag in your life, come
-        anyway — I'll get you from blank file to live page before the sun gets
-        too low over the river.
-      </p>
+      <h2>Good to know</h2>
+      <ul class="notes">
+        <li><strong>Bring a blanket</strong> — we'll be on the grass.</li>
+        <li>I'm bringing a sandwich; pack a snack or a picnic of your own.</li>
+        <li>
+          My kid will be hanging with us for part of the afternoon, so it's a
+          kid-friendly crowd.
+        </li>
+        <li>Poetry welcome and encouraged — HTML optional but lovely.</li>
+        <li>Charge your battery; there are no outlets in the park.</li>
+      </ul>
 
-      <section class="details" aria-label="Event details">
-        <h2 style="margin-top: 0">The details</h2>
-        <dl>
-          <dt>What</dt>
-          <dd>An html.energy freewrite for HTML Day 2026</dd>
-          <dt>When</dt>
-          <dd>Saturday, August 8th, 2026 · 2:00–5:00 PM</dd>
-          <dt>Where</dt>
-          <dd>Astoria Park, by the Hell Gate Bridge · Astoria, Queens, NY</dd>
-          <dt>Cost</dt>
-          <dd>Free — all are welcome</dd>
-          <dt>Bring</dt>
-          <dd>A laptop, a charged battery, and an idea</dd>
-          <dt>Host</dt>
-          <dd><a href="https://eligundry.com">Eli Gundry</a></dd>
-        </dl>
-      </section>
-
-      <p>
-        Come write some HTML with me. I had a ball making this very page by hand
-        — won't you join me and the
-        <a href="https://html.energy">web0</a> movement?
-      </p>
+      <div class="rsvp">
+        <p class="label">RSVP / questions — text Eli</p>
+        <div class="number">
+          <a href="tel:+13475232652">347.523.2652</a>
+        </div>
+      </div>
 
       <footer>
-        <p>
-          <span class="star">✳️</span>
-          <a href="https://eligundry.com">Eli Gundry</a>
-          <span class="star">✳️</span>
-        </p>
+        <span class="star">✳️</span>
+        hosted by <a href="https://eligundry.com">Eli Gundry</a>
+        <span class="star">✳️</span>
       </footer>
 
       <div
@@ -298,6 +499,20 @@
         Hell Gate Bridge — rendered in html.energy green, the way it glows over
         the park at golden hour.
       </p>
-    </main>
+
+      <p class="tearoffs-label">✂ — tear off my number — ✂</p>
+      <div class="tearoffs" aria-hidden="true">
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+        <div class="tab">HTML Day ✳ <span class="num">347.523.2652</span></div>
+      </div>
+    </article>
   </body>
 </html>

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -292,10 +292,12 @@
           color: #000;
         }
 
-        /* Stars and headings print as solid black ink — no glow, no toner-hungry fills. */
+        /* Let the ✳️ stars keep their html.energy glow on paper too. */
         .star {
-          color: #000;
-          text-shadow: none;
+          color: var(--energy-green);
+          text-shadow:
+            0 0 3px var(--energy-green),
+            0 0 9px var(--energy-green);
         }
 
         .masthead {
@@ -354,7 +356,8 @@
           background: #fff;
           color: #000;
           border: 2px solid #000;
-          text-shadow: none;
+          /* A faint green halo so a whisper of html.energy survives on paper. */
+          text-shadow: 0 0 2px rgba(57, 255, 20, 0.55);
           overflow: visible;
           margin-top: 0.6rem;
           padding: 0.3rem;
@@ -370,15 +373,49 @@
 
         .rsvp {
           margin-top: 0.6rem;
-          padding: 0.55rem;
+          padding: 0.55rem 0.75rem;
+          /* On paper: copy on the left, scannable QR on the right. */
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 0.75rem;
+          text-align: left;
         }
 
         .rsvp .number {
           font-size: 18pt;
         }
 
+        .rsvp .label,
+        .rsvp .site {
+          text-align: left;
+        }
+
+        .qr {
+          margin: 0;
+          flex: 0 0 auto;
+          text-align: center;
+        }
+
+        .qr .qr-code {
+          width: 0.95in;
+          height: 0.95in;
+          color: #000;
+        }
+
+        .qr figcaption {
+          font-size: 7pt;
+          text-transform: uppercase;
+          letter-spacing: 0.12em;
+          margin-top: 0.15rem;
+        }
+
         .tearoffs-label {
           margin-top: 0.7rem;
+        }
+
+        .tearoffs {
+          display: flex;
         }
 
         .tearoffs,
@@ -400,7 +437,9 @@
       }
 
       .tearoffs {
-        display: flex;
+        /* Hidden everywhere by default; only the print stylesheet turns these
+           on (as a flex row). Keeps them off screen and out of the way. */
+        display: none;
         flex-wrap: nowrap;
         border-top: 2px dashed #000;
         margin-top: 0.3rem;
@@ -550,8 +589,8 @@
         </p>
         <p>
           Bring a laptop, a blanket, and a full battery (there are no outlets
-          out here). New to code? I'll show you the ropes. Kids welcome and
-          poetry encouraged — or just come watch the bridge and say hello.
+          out here). New to code? I'll show you the ropes. Poetry encouraged —
+          or just come watch the bridge and say hello.
         </p>
       </div>
 
@@ -563,7 +602,6 @@
             Pack your own snack or picnic — I'm bringing a sandwich, and no, I'm
             not sharing it.
           </li>
-          <li>It's a kid-friendly crowd — little ones welcome.</li>
           <li>Poetry welcome and encouraged — HTML optional but lovely.</li>
           <li>Charge your battery; there are no outlets in the park.</li>
         </ul>
@@ -575,17 +613,35 @@
         itemscope
         itemtype="https://schema.org/Person"
       >
-        <p class="label">RSVP / questions — text Eli</p>
-        <div class="number">
-          <a itemprop="telephone" href="tel:+13475232652">347.523.2652</a>
+        <div class="rsvp-text">
+          <p class="label">RSVP / questions — text Eli</p>
+          <div class="number">
+            <a itemprop="telephone" href="tel:+13475232652">347.523.2652</a>
+          </div>
+          <p class="site">
+            <a
+              itemprop="url"
+              href="https://eligundry.com/astoria-html-day-2026.html"
+              >eligundry.com/astoria-html-day-2026</a
+            >
+          </p>
         </div>
-        <p class="site">
-          <a
-            itemprop="url"
-            href="https://eligundry.com/astoria-html-day-2026.html"
-            >eligundry.com/astoria-html-day-2026</a
+        <!-- Printed-flyer QR linking straight to this page. -->
+        <figure class="qr print-only">
+          <svg
+            class="qr-code"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 33 33"
+            shape-rendering="crispEdges"
+            fill="currentColor"
+            aria-hidden="true"
           >
-        </p>
+            <path
+              d="M0 0h7v1h-7zM9 0h3v1h-3zM18 0h2v1h-2zM23 0h1v1h-1zM26 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM9 1h1v1h-1zM15 1h2v1h-2zM18 1h1v1h-1zM20 1h2v1h-2zM26 1h1v1h-1zM32 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h5v1h-5zM14 2h2v1h-2zM20 2h2v1h-2zM26 2h1v1h-1zM28 2h3v1h-3zM32 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h3v1h-3zM15 3h1v1h-1zM18 3h2v1h-2zM22 3h1v1h-1zM24 3h1v1h-1zM26 3h1v1h-1zM28 3h3v1h-3zM32 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM13 4h5v1h-5zM20 4h1v1h-1zM22 4h2v1h-2zM26 4h1v1h-1zM28 4h3v1h-3zM32 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM10 5h2v1h-2zM14 5h1v1h-1zM17 5h1v1h-1zM19 5h1v1h-1zM22 5h1v1h-1zM24 5h1v1h-1zM26 5h1v1h-1zM32 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h7v1h-7zM8 7h5v1h-5zM14 7h1v1h-1zM16 7h1v1h-1zM19 7h3v1h-3zM23 7h1v1h-1zM0 8h1v1h-1zM2 8h5v1h-5zM10 8h2v1h-2zM13 8h2v1h-2zM17 8h1v1h-1zM19 8h1v1h-1zM22 8h2v1h-2zM26 8h5v1h-5zM3 9h2v1h-2zM7 9h1v1h-1zM10 9h4v1h-4zM16 9h6v1h-6zM23 9h1v1h-1zM26 9h2v1h-2zM29 9h2v1h-2zM32 9h1v1h-1zM2 10h2v1h-2zM6 10h3v1h-3zM10 10h1v1h-1zM12 10h6v1h-6zM20 10h3v1h-3zM25 10h2v1h-2zM28 10h1v1h-1zM30 10h2v1h-2zM1 11h1v1h-1zM3 11h2v1h-2zM13 11h1v1h-1zM15 11h1v1h-1zM17 11h5v1h-5zM23 11h1v1h-1zM25 11h1v1h-1zM28 11h4v1h-4zM1 12h1v1h-1zM3 12h5v1h-5zM9 12h1v1h-1zM11 12h2v1h-2zM14 12h1v1h-1zM16 12h1v1h-1zM19 12h2v1h-2zM22 12h1v1h-1zM24 12h1v1h-1zM27 12h3v1h-3zM31 12h2v1h-2zM0 13h2v1h-2zM3 13h1v1h-1zM7 13h1v1h-1zM10 13h2v1h-2zM15 13h1v1h-1zM18 13h1v1h-1zM21 13h1v1h-1zM23 13h5v1h-5zM29 13h1v1h-1zM31 13h2v1h-2zM1 14h1v1h-1zM6 14h3v1h-3zM12 14h1v1h-1zM14 14h3v1h-3zM18 14h1v1h-1zM20 14h3v1h-3zM24 14h3v1h-3zM30 14h2v1h-2zM1 15h2v1h-2zM4 15h1v1h-1zM10 15h1v1h-1zM13 15h1v1h-1zM15 15h1v1h-1zM21 15h1v1h-1zM23 15h1v1h-1zM25 15h4v1h-4zM30 15h1v1h-1zM0 16h1v1h-1zM2 16h1v1h-1zM6 16h3v1h-3zM12 16h1v1h-1zM15 16h1v1h-1zM17 16h1v1h-1zM22 16h1v1h-1zM24 16h2v1h-2zM27 16h2v1h-2zM32 16h1v1h-1zM2 17h1v1h-1zM4 17h2v1h-2zM8 17h3v1h-3zM12 17h1v1h-1zM16 17h1v1h-1zM19 17h2v1h-2zM22 17h2v1h-2zM26 17h2v1h-2zM29 17h2v1h-2zM32 17h1v1h-1zM3 18h4v1h-4zM9 18h3v1h-3zM13 18h1v1h-1zM15 18h1v1h-1zM18 18h1v1h-1zM20 18h3v1h-3zM27 18h2v1h-2zM30 18h2v1h-2zM1 19h2v1h-2zM4 19h2v1h-2zM8 19h2v1h-2zM12 19h2v1h-2zM19 19h1v1h-1zM21 19h2v1h-2zM24 19h1v1h-1zM26 19h5v1h-5zM0 20h2v1h-2zM3 20h2v1h-2zM6 20h2v1h-2zM10 20h2v1h-2zM15 20h1v1h-1zM18 20h1v1h-1zM22 20h2v1h-2zM28 20h2v1h-2zM31 20h1v1h-1zM0 21h1v1h-1zM2 21h2v1h-2zM5 21h1v1h-1zM7 21h1v1h-1zM9 21h1v1h-1zM11 21h2v1h-2zM14 21h3v1h-3zM20 21h2v1h-2zM23 21h4v1h-4zM29 21h1v1h-1zM32 21h1v1h-1zM0 22h1v1h-1zM3 22h1v1h-1zM5 22h3v1h-3zM10 22h4v1h-4zM17 22h3v1h-3zM24 22h2v1h-2zM29 22h3v1h-3zM0 23h1v1h-1zM2 23h2v1h-2zM5 23h1v1h-1zM8 23h3v1h-3zM16 23h1v1h-1zM19 23h3v1h-3zM23 23h3v1h-3zM27 23h1v1h-1zM29 23h2v1h-2zM0 24h1v1h-1zM4 24h4v1h-4zM10 24h1v1h-1zM12 24h2v1h-2zM16 24h2v1h-2zM19 24h1v1h-1zM22 24h1v1h-1zM24 24h5v1h-5zM8 25h1v1h-1zM10 25h1v1h-1zM12 25h1v1h-1zM16 25h2v1h-2zM19 25h2v1h-2zM22 25h1v1h-1zM24 25h1v1h-1zM28 25h1v1h-1zM30 25h3v1h-3zM0 26h7v1h-7zM9 26h3v1h-3zM14 26h4v1h-4zM21 26h4v1h-4zM26 26h1v1h-1zM28 26h1v1h-1zM30 26h2v1h-2zM0 27h1v1h-1zM6 27h1v1h-1zM8 27h1v1h-1zM12 27h2v1h-2zM16 27h6v1h-6zM23 27h2v1h-2zM28 27h3v1h-3zM0 28h1v1h-1zM2 28h3v1h-3zM6 28h1v1h-1zM8 28h2v1h-2zM12 28h1v1h-1zM14 28h1v1h-1zM16 28h1v1h-1zM19 28h1v1h-1zM21 28h1v1h-1zM24 28h6v1h-6zM32 28h1v1h-1zM0 29h1v1h-1zM2 29h3v1h-3zM6 29h1v1h-1zM8 29h2v1h-2zM13 29h3v1h-3zM18 29h1v1h-1zM24 29h2v1h-2zM28 29h5v1h-5zM0 30h1v1h-1zM2 30h3v1h-3zM6 30h1v1h-1zM8 30h4v1h-4zM13 30h4v1h-4zM21 30h1v1h-1zM23 30h1v1h-1zM26 30h2v1h-2zM30 30h1v1h-1zM0 31h1v1h-1zM6 31h1v1h-1zM10 31h2v1h-2zM13 31h1v1h-1zM15 31h1v1h-1zM18 31h1v1h-1zM21 31h3v1h-3zM28 31h3v1h-3zM0 32h7v1h-7zM8 32h1v1h-1zM11 32h1v1h-1zM14 32h2v1h-2zM17 32h1v1h-1zM24 32h1v1h-1zM27 32h1v1h-1zM31 32h1v1h-1z"
+            />
+          </svg>
+          <figcaption>Scan for details</figcaption>
+        </figure>
         <meta itemprop="name" content="Eli Gundry" />
       </address>
 

--- a/src/pages/astoria-html-day-2026.html
+++ b/src/pages/astoria-html-day-2026.html
@@ -512,7 +512,10 @@
         <h2>Good to know</h2>
         <ul class="notes">
           <li><strong>Bring a blanket</strong> — we'll be on the grass.</li>
-          <li>Pack a snack or a picnic; there'll be sandwiches to share.</li>
+          <li>
+            Pack your own snack or picnic — I'm bringing a sandwich, and no, I'm
+            not sharing it.
+          </li>
           <li>It's a kid-friendly crowd — little ones welcome.</li>
           <li>Poetry welcome and encouraged — HTML optional but lovely.</li>
           <li>Charge your battery; there are no outlets in the park.</li>

--- a/src/pages/web0.html
+++ b/src/pages/web0.html
@@ -56,6 +56,13 @@
       <h2>HTML Energy Projects</h2>
       <ul>
         <li>
+          <a href="/astoria-html-day-2026.html">HTML Day 2026 in Astoria Park</a
+          >: A community freewrite I'm hosting for HTML Day 2026, on the South
+          Hill of Astoria Park under the Hell Gate Bridge. Come write some HTML
+          by hand with the neighborhood — it's a flyer too, so print one and
+          post it.
+        </li>
+        <li>
           <a href="/saturdays">Saturdays</a>: A poem about the weekly phone
           calls I have with my brother in law for HTML Day 2025. I dislike AI
           art in general, but I wanted this to have some polish, so I cheated.


### PR DESCRIPTION
A standalone html.energy-style page announcing a freewrite in Astoria
Park on HTML Day 2026 (Aug 8, 2-5pm), under the Hell Gate Bridge.
Includes schema.org Event JSON-LD and an ASCII Hell Gate Bridge
rendered in html.energy green on black.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017qDFG2VXjaecSnSo6fH6ZA